### PR TITLE
[DesignToken] background の semantic color に base を追加し、base-primary, base-secondary, base-accent を削除

### DIFF
--- a/.changeset/silent-rivers-love.md
+++ b/.changeset/silent-rivers-love.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-design-tokens": patch
+---
+
+[change] background-color に base を追加し、base-primary, base-secondary, base-accent を削除

--- a/packages/designTokens/tokens/semantics/brands/g4b-light/index.tokens.json
+++ b/packages/designTokens/tokens/semantics/brands/g4b-light/index.tokens.json
@@ -36,11 +36,7 @@
           "$type": "color",
           "$value": "{global.color.slate.100}"
         },
-        "base-primary": {
-          "$type": "color",
-          "$value": "{global.color.white.800}"
-        },
-        "base-secondary": {
+        "base": {
           "$type": "color",
           "$value": "{global.color.steel.50}"
         },
@@ -53,10 +49,6 @@
           "$value": "{global.color.steel.100}"
         },
         "rest-accent": {
-          "$type": "color",
-          "$value": "{semantic.color.background.brand-secondary}"
-        },
-        "base-accent": {
           "$type": "color",
           "$value": "{semantic.color.background.brand-secondary}"
         },
@@ -116,10 +108,6 @@
           "$type": "color",
           "$value": "{semantic.color.brand.lighter}"
         },
-        "overlay": {
-          "$type": "color",
-          "$value": "{global.color.transparency.slate.70}"
-        },
         "neutral-primary": {
           "$type": "color",
           "$value": "{global.color.white.800}"
@@ -127,6 +115,10 @@
         "neutral-secondary": {
           "$type": "color",
           "$value": "{global.color.white.800}"
+        },
+        "overlay": {
+          "$type": "color",
+          "$value": "{global.color.transparency.slate.70}"
         }
       },
       "border": {

--- a/packages/designTokens/tokens/semantics/brands/skeleton-light/index.tokens.json
+++ b/packages/designTokens/tokens/semantics/brands/skeleton-light/index.tokens.json
@@ -36,13 +36,9 @@
           "$type": "color",
           "$value": "{global.color.slate.100}"
         },
-        "base-primary": {
+        "base": {
           "$type": "color",
           "$value": "{global.color.slate.50}"
-        },
-        "base-secondary": {
-          "$type": "color",
-          "$value": "{global.color.white.800}"
         },
         "rest-primary": {
           "$type": "color",
@@ -53,10 +49,6 @@
           "$value": "{global.color.slate.100}"
         },
         "rest-accent": {
-          "$type": "color",
-          "$value": "{semantic.color.background.brand-secondary}"
-        },
-        "base-accent": {
           "$type": "color",
           "$value": "{semantic.color.background.brand-secondary}"
         },
@@ -116,10 +108,6 @@
           "$type": "color",
           "$value": "{semantic.color.brand.lightest}"
         },
-        "overlay": {
-          "$type": "color",
-          "$value": "{global.color.transparency.slate.70}"
-        },
         "neutral-primary": {
           "$type": "color",
           "$value": "{global.color.white.800}"
@@ -127,6 +115,10 @@
         "neutral-secondary": {
           "$type": "color",
           "$value": "{global.color.white.800}"
+        },
+        "overlay": {
+          "$type": "color",
+          "$value": "{global.color.transparency.slate.70}"
         }
       },
       "border": {


### PR DESCRIPTION
## 概要

* background の semantic color に base を追加
* また、base-primary, base-secondary, base-accent を削除

## スクリーンショット

## ユーザ影響

* base-primary, base-secondary, base-accent の利用者は以下のように移行
    * アプリケーション全体の背景色は、base へ
    * 部分的な base-primary => rest-primary
    * base-secondary => rest-secondary
    * base-accent => rest-accent
