### PR TITLE
[内部改善] PR で build CI が回るようにする

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,6 +1,9 @@
 name: build_test
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main


### PR DESCRIPTION
## 概要

* PR を挙げた際に CI が回らないので、特にデザイントークン関連で CI が回らないことがある
* よって、PR タイミングで build の CI は回すようにする

## スクリーンショット



## ユーザ影響


