### PR TITLE
[CSS] Modal の bg-color に base を付与

### DIFF
--- a/.changeset/calm-ties-promise.md
+++ b/.changeset/calm-ties-promise.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[change] Modal の bg-color に bg-base を付与

--- a/packages/css/src/components/modal/index.scss
+++ b/packages/css/src/components/modal/index.scss
@@ -2,7 +2,7 @@
   border: none;
   padding: var(--ab-semantic-spacing-0);
   border-radius: var(--ab-semantic-border-radius-md);
-  background-color: var(--ab-semantic-color-background-rest-primary);
+  background-color: var(--ab-semantic-color-background-base);
   max-height: 100%;
   width: 100%;
   overflow-y: auto;

--- a/packages/css/src/components/modal/stories/Base.stories.ts
+++ b/packages/css/src/components/modal/stories/Base.stories.ts
@@ -14,7 +14,7 @@ export const Base: Story = {
   <dialog id="modal" class="ab-Modal" style="width: 800px">
     <form method="dialog">
       <div class="ab-Modal-header">
-        <button class="ab-IconButton-negative ab-IconButton-small ab-mr-2">
+        <button class="ab-IconButton-text ab-IconButton-small ab-mr-2">
           X
         </button>
         <span class="ab-font-bold">モーダル Header</span>


### PR DESCRIPTION
## 概要

* Modal の bg-color に base を付与

## スクリーンショット

<img width="727" alt="スクリーンショット 2024-07-22 23 37 00" src="https://github.com/user-attachments/assets/aeb4bd1f-b355-4073-865d-bf232b2e3393">


## ユーザ影響

* Modal の bg-color を変更
