### PR TITLE
[DesignToken] skeleton light の rest-secondary をslate.100 から steel.100 に変更

### DIFF
--- a/.changeset/popular-hairs-shout.md
+++ b/.changeset/popular-hairs-shout.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-design-tokens": patch
+---
+
+[change] background color の rest-secondary の color を slate.100 から steel.100 にする

--- a/packages/designTokens/tokens/semantics/brands/skeleton-light/index.tokens.json
+++ b/packages/designTokens/tokens/semantics/brands/skeleton-light/index.tokens.json
@@ -46,7 +46,7 @@
         },
         "rest-secondary": {
           "$type": "color",
-          "$value": "{global.color.slate.100}"
+          "$value": "{global.color.steel.100}"
         },
         "rest-accent": {
           "$type": "color",


### PR DESCRIPTION
## 概要

* 現状、skeleton light の rest-secondary をslate.100 になっている
* しかし、本来は steel.100 なのでそれに合わせる

## スクリーンショット

## ユーザ影響

* カラーはほとんど同じなので、知覚できる影響はほとんどなし
