### PR TITLE
[CSS] IconButton の negative を neutral に rename

### DIFF
--- a/.changeset/fast-mayflies-dream.md
+++ b/.changeset/fast-mayflies-dream.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[breaking change] IconButton の negative を neutral に rename

--- a/packages/css/src/components/iconbutton/index.scss
+++ b/packages/css/src/components/iconbutton/index.scss
@@ -39,11 +39,6 @@
   @extend .ab-IconButton;
 }
 
-.ab-IconButton-negative {
-  @extend .ab-Button-negative;
-  @extend .ab-IconButton;
-}
-
 .ab-IconButton-neutral {
   @extend .ab-Button-neutral;
   @extend .ab-IconButton;

--- a/packages/css/src/components/iconbutton/stories/Type.stories.ts
+++ b/packages/css/src/components/iconbutton/stories/Type.stories.ts
@@ -11,7 +11,7 @@ export const Type: Story = {
     return `
 ${createComponent({ ...args, type: 'default' })}
 ${createComponent({ ...args, type: 'outlined' })}
-${createComponent({ ...args, type: 'negative' })}
+${createComponent({ ...args, type: 'neutral' })}
 ${createComponent({ ...args, type: 'text' })}
   `;
   },

--- a/packages/css/src/components/iconbutton/stories/shared.ts
+++ b/packages/css/src/components/iconbutton/stories/shared.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { plus } from '../../../../story_assets/inlines';
 
 export type Args = {
-  type: 'default' | 'outlined' | 'negative' | 'neutral' | 'text';
+  type: 'default' | 'outlined' | 'neutral' | 'text';
   size: 'small' | 'medium' | 'large';
 };
 
@@ -10,7 +10,7 @@ export const meta: Meta<Args> = {
   argTypes: {
     type: {
       control: { type: 'select' },
-      options: ['default', 'outlined', 'negative', 'neutral', 'text'],
+      options: ['default', 'outlined', 'neutral', 'text'],
     },
     size: {
       control: { type: 'select' },


### PR DESCRIPTION
## 概要

* IconButton の negative を neutral に rename

## スクリーンショット

![スクリーンショット 2024-07-24 11 45 13](https://github.com/user-attachments/assets/6c4893cf-9327-4e54-afdb-48207f951e9d)



## ユーザ影響

* negative は neutral に移行をお願いいたします
