### PR TITLE
[React] Button の negative を neutral にリネームし、negative color で negative を追加

### DIFF
--- a/.changeset/slimy-cycles-carry.md
+++ b/.changeset/slimy-cycles-carry.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-react": patch
+---
+
+[breaking change] Button の negative を neutral にリネームし、negative color の negative を追加

--- a/packages/react/src/components/button/Button.stories.tsx
+++ b/packages/react/src/components/button/Button.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
   argTypes: {
     variant: {
       control: { type: 'select' },
-      options: ['default', 'outlined', 'negative', 'text'],
+      options: ['default', 'outlined', 'neutral', 'negative', 'text'],
       table: {
         defaultValue: {
           summary: 'default',
@@ -45,6 +45,9 @@ export const Variant: Story = {
         {children}
       </Button>
       <Button {...args} variant="outlined">
+        {children}
+      </Button>
+      <Button {...args} variant="neutral">
         {children}
       </Button>
       <Button {...args} variant="negative">

--- a/packages/react/src/components/button/Index.tsx
+++ b/packages/react/src/components/button/Index.tsx
@@ -7,7 +7,7 @@ export type ButtonProps = Omit<
   'onClick'
 > &
   Omit<ComponentPropsWithoutRef<'a'>, 'onClick'> & {
-    variant?: 'default' | 'outlined' | 'negative' | 'text';
+    variant?: 'default' | 'outlined' | 'neutral' | 'negative' | 'text';
     size?: 'xsmall' | 'small' | 'large';
     component?: React.ElementType;
     onClick?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;

--- a/packages/react/src/components/modal/Modal.stories.tsx
+++ b/packages/react/src/components/modal/Modal.stories.tsx
@@ -65,7 +65,7 @@ export const Base: Story = {
           <Modal.Body>モーダル Body</Modal.Body>
           <Divider />
           <Modal.Footer>
-            <Button variant="negative">Cancel</Button>
+            <Button variant="neutral">Cancel</Button>
             <Button>OK</Button>
           </Modal.Footer>
         </Modal.Root>
@@ -112,7 +112,7 @@ export const Form: Story = {
           </Modal.Body>
           <Divider />
           <Modal.Footer>
-            <Button variant="negative">Cancel</Button>
+            <Button variant="neutral">Cancel</Button>
             <Button type="submit" onClick={handleSubmit}>
               OK
             </Button>


### PR DESCRIPTION
## 概要

* Button の negative を neutral にリネームし、negative color で negative を追加

## スクリーンショット
![スクリーンショット 2024-07-24 11 51 21](https://github.com/user-attachments/assets/2d2c17b2-727a-4efa-b62c-1f6e0ee2ed83)



## ユーザ影響

* negative は neutral にリネームをお願いします
