### PR TITLE
[React] IconButton の negative を neutral にリネーム

### DIFF
--- a/.changeset/six-houses-smell.md
+++ b/.changeset/six-houses-smell.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-react": patch
+---
+
+[breaking change] IconButton の negative を neutral にリネーム

--- a/packages/react/src/components/iconButton/IconButton.stories.tsx
+++ b/packages/react/src/components/iconButton/IconButton.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
   argTypes: {
     variant: {
       control: { type: 'select' },
-      options: ['default', 'outlined', 'negative', 'text'],
+      options: ['default', 'outlined', 'neutral', 'text'],
       table: {
         defaultValue: {
           summary: 'default',
@@ -48,7 +48,7 @@ export const Variant: Story = {
       <IconButton {...args} variant="outlined">
         {children}
       </IconButton>
-      <IconButton {...args} variant="negative">
+      <IconButton {...args} variant="neutral">
         {children}
       </IconButton>
       <IconButton {...args} variant="text">

--- a/packages/react/src/components/iconButton/Index.tsx
+++ b/packages/react/src/components/iconButton/Index.tsx
@@ -3,7 +3,7 @@ import { classNames } from '@/utils/classNames';
 import type { ComponentPropsWithoutRef, ElementRef } from 'react';
 
 export type IconButtonProps = ComponentPropsWithoutRef<'button'> & {
-  variant?: 'default' | 'outlined' | 'negative' | 'text';
+  variant?: 'default' | 'outlined' | 'neutral' | 'text';
   size?: 'small' | 'large';
 };
 

--- a/packages/react/src/components/modal/Modal.stories.tsx
+++ b/packages/react/src/components/modal/Modal.stories.tsx
@@ -50,7 +50,7 @@ export const Base: Story = {
           open={open}
         >
           <Modal.Header>
-            <IconButton variant="negative" size="small" className="ab-mr-2">
+            <IconButton variant="neutral" size="small" className="ab-mr-2">
               X
             </IconButton>
             <Typography
@@ -91,7 +91,7 @@ export const Form: Story = {
         <Button onClick={handleOpen}>Open Modal{open}</Button>
         <Modal.Root onClose={handleClose} onCancel={handleCancel} open={open}>
           <Modal.Header>
-            <IconButton variant="negative" size="small" className="ab-mr-2">
+            <IconButton variant="neutral" size="small" className="ab-mr-2">
               X
             </IconButton>
             <Typography


### PR DESCRIPTION
## 概要

* IconButton の negative を neutral にリネーム

## スクリーンショット

![スクリーンショット 2024-07-24 11 56 20](https://github.com/user-attachments/assets/4e415444-3ae7-47f3-af9a-6cc56b4643fb)


## ユーザ影響

* negative => neutral へのリネームをお願いします
