### PR TITLE
[CSS] LinkText を inline 要素にするために inline-flex を利用

### DIFF
--- a/.changeset/nice-points-pay.md
+++ b/.changeset/nice-points-pay.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[enhancement:LinkText] LinkText が block 要素にならないように display: flex を inline-flex に変更

--- a/packages/css/src/components/linktext/index.scss
+++ b/packages/css/src/components/linktext/index.scss
@@ -32,7 +32,7 @@
     color 0.3s,
     text-decoration 0.3s;
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: var(--ab-semantic-spacing-2);
 


### PR DESCRIPTION
## 概要

* display: flex を適用していたため、block 要素になっていた
* そこで inline 要素にするために inline-flex とする

## スクリーンショット

## ユーザ影響

* LinkText が inline 要素になります
