### PR TITLE
[DesignToken] font-weight normal のデザイントークンを regular から 400 に修正

### DIFF
--- a/.changeset/chilled-rings-explain.md
+++ b/.changeset/chilled-rings-explain.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-design-tokens": patch
+---
+
+[fix:font-weight] font-weight: 400 のデザイントークンを regular から 400 に修正

--- a/packages/designTokens/tokens/globals/index.tokens.json
+++ b/packages/designTokens/tokens/globals/index.tokens.json
@@ -13,12 +13,12 @@
       },
       "weight": {
         "400": {
-          "$type": "string",
-          "$value": "regular"
+          "$type": "number",
+          "$value": 400
         },
         "700": {
-          "$type": "string",
-          "$value": "bold"
+          "$type": "number",
+          "$value": 700
         }
       },
       "size": {

--- a/packages/designTokens/tokens/semantics/common/index.tokens.json
+++ b/packages/designTokens/tokens/semantics/common/index.tokens.json
@@ -131,11 +131,11 @@
       },
       "font-weight": {
         "regular": {
-          "$type": "string",
+          "$type": "number",
           "$value": "{global.font.weight.400}"
         },
         "bold": {
-          "$type": "string",
+          "$type": "number",
           "$value": "{global.font.weight.700}"
         }
       },


### PR DESCRIPTION
## 概要

* font-weight normal のデザイントークンを regular になっている
* しかし、regular は CSS 的に不正な値なので 400 に変更する
* なお、normal も検討したが断念
    * 本デザイントークンは Figma Variables として管理し、Figma の text style にも利用されている
    * しかし、normal は Figma の text style 的に不正な値なので、400 を利用する

## スクリーンショット

<img width="581" alt="スクリーンショット 2024-07-30 21 02 54" src="https://github.com/user-attachments/assets/f52826f0-2c2b-4021-a99b-492489d3400b">


## ユーザ影響

* なし
