### PR TITLE
[React] Divider から size props を削除

### DIFF
--- a/.changeset/lovely-zoos-promise.md
+++ b/.changeset/lovely-zoos-promise.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-react": patch
+---
+
+[breakingchange:Divider] size props を削除

--- a/packages/react/src/components/divider/Divider.stories.tsx
+++ b/packages/react/src/components/divider/Divider.stories.tsx
@@ -8,7 +8,6 @@ const meta = {
   component: Divider,
   args: {
     direction: 'horizontal',
-    size: 'small',
   },
   argTypes: {
     direction: {
@@ -20,16 +19,6 @@ const meta = {
         },
       },
       description: '方向',
-    },
-    size: {
-      control: { type: 'select' },
-      options: ['small', 'medium', 'large'],
-      table: {
-        defaultValue: {
-          summary: 'small',
-        },
-      },
-      description: 'サイズ',
     },
   },
 } satisfies Meta<typeof Divider>;
@@ -50,16 +39,6 @@ export const Direction: Story = {
       <div className="ab-flex ab-gap-8">
         X<Divider {...args} direction="vertical"></Divider>X
       </div>
-    </div>
-  ),
-};
-
-export const Size: Story = {
-  render: ({ ...args }: DividerProps) => (
-    <div className="ab-flex ab-flex-column ab-gap-8">
-      <Divider {...args} size="small"></Divider>
-      <Divider {...args} size="medium"></Divider>
-      <Divider {...args} size="large"></Divider>
     </div>
   ),
 };

--- a/packages/react/src/components/divider/Index.tsx
+++ b/packages/react/src/components/divider/Index.tsx
@@ -4,18 +4,13 @@ import type { ComponentPropsWithoutRef, ElementRef } from 'react';
 
 export type DividerProps = Omit<ComponentPropsWithoutRef<'hr'>, 'children'> & {
   direction?: 'horizontal' | 'vertical';
-  size?: 'small' | 'medium' | 'large';
 };
 
 export const Divider = forwardRef<ElementRef<'hr'>, DividerProps>(
-  (
-    { direction = 'horizontal', size = 'small', className, ...rest },
-    forwardedRef,
-  ) => {
+  ({ direction = 'horizontal', className, ...rest }, forwardedRef) => {
     const classes = classNames(
       'ab-Divider',
       `ab-Divider-${direction}`,
-      `ab-Divider-${size}`,
       className,
     );
 


### PR DESCRIPTION
## 概要

* Divider から size props を削除

## スクリーンショット


## ユーザ影響

* Divider から size はなくなり、1px のみになります
