### PR TITLE
[CSS] border-radius utility で方向指定を可能にした

### DIFF
--- a/.changeset/sharp-hounds-compete.md
+++ b/.changeset/sharp-hounds-compete.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[add:border-radius] border-radius に方向指定ができるようにした

--- a/packages/css/src/utilities/border/index.scss
+++ b/packages/css/src/utilities/border/index.scss
@@ -25,4 +25,44 @@ $sides: (
   .ab-rounded-#{$radiusKey} {
     border-radius: #{$radiusValue};
   }
+
+  .ab-rounded-t-#{$radiusKey} {
+    border-top-left-radius: #{$radiusValue};
+    border-top-right-radius: #{$radiusValue};
+  }
+
+  .ab-rounded-r-#{$radiusKey} {
+    border-top-right-radius: #{$radiusValue};
+    border-bottom-right-radius: #{$radiusValue};
+  }
+
+  .ab-rounded-b-#{$radiusKey} {
+    border-bottom-right-radius: #{$radiusValue};
+    border-bottom-left-radius: #{$radiusValue};
+  }
+
+  .ab-rounded-l-#{$radiusKey} {
+    border-top-left-radius: #{$radiusValue};
+    border-bottom-left-radius: #{$radiusValue};
+  }
+
+  .ab-rounded-tl-#{$radiusKey} {
+    border-top-left-radius: #{$radiusValue};
+  }
+
+  .ab-rounded-tl-#{$radiusKey} {
+    border-top-left-radius: #{$radiusValue};
+  }
+
+  .ab-rounded-tr-#{$radiusKey} {
+    border-top-right-radius: #{$radiusValue};
+  }
+
+  .ab-rounded-br-#{$radiusKey} {
+    border-bottom-right-radius: #{$radiusValue};
+  }
+
+  .ab-rounded-bl-#{$radiusKey} {
+    border-bottom-left-radius: #{$radiusValue};
+  }
 }

--- a/packages/css/src/utilities/border/stories/BorderRadius.stories.ts
+++ b/packages/css/src/utilities/border/stories/BorderRadius.stories.ts
@@ -9,26 +9,64 @@ export default {
 export const BorderRadius: Story = {
   render: (_args) => {
     return `
-<div class="ab-flex ab-flex-column ab-gap-8">
-  <div class="ab-flex ab-gap-2">
-    <div class="ab-border ab-rounded-none ab-bg-disabled ab-w-32 ab-h-32"></div>
-    <span>none: radius を利用したくない場合に使います</span>
+<div class="ab-flex ab-flex-column ab-gap-16">
+  <div class="ab-flex ab-flex-column ab-gap-8">
+    <p class="ab-text-headline-s">border-radius の大きさは以下を参考に</p>
+    <div class="ab-flex ab-gap-2">
+      <div class="ab-border ab-rounded-none ab-bg-disabled ab-w-32 ab-h-32"></div>
+      <span>none: radius を利用したくない場合に使います</span>
+    </div>
+    <div class="ab-flex ab-gap-2">
+      <div class="ab-border ab-rounded-xs ab-bg-disabled ab-w-8 ab-h-8"></div>
+      <span>xs: 〜16px に収まる範囲のものに主に使います</span>
+    </div>
+    <div class="ab-flex ab-gap-2">
+      <div class="ab-border ab-rounded-sm ab-bg-disabled ab-w-32 ab-h-32"></div>
+      <span>sm: 16〜64px に収まる範囲のものに主に使います</span>
+    </div>
+    <div class="ab-flex ab-gap-2">
+      <div class="ab-border ab-rounded-md ab-bg-disabled ab-w-80 ab-h-80"></div>
+      <span>md: 64〜480px に収まる範囲のものに主に使います</span>
+    </div>
+    <div class="ab-flex ab-gap-2">
+      <div class="ab-border ab-rounded-lg ab-bg-disabled ab-w-120 ab-h-120"></div>
+      <span>lg: 480px 以上のものに主に使います</span>
+    </div>
   </div>
-  <div class="ab-flex ab-gap-2">
-    <div class="ab-border ab-rounded-xs ab-bg-disabled ab-w-8 ab-h-8"></div>
-    <span>xs: 〜16px に収まる範囲のものに主に使います</span>
-  </div>
-  <div class="ab-flex ab-gap-2">
-    <div class="ab-border ab-rounded-sm ab-bg-disabled ab-w-32 ab-h-32"></div>
-    <span>sm: 16〜64px に収まる範囲のものに主に使います</span>
-  </div>
-  <div class="ab-flex ab-gap-2">
-    <div class="ab-border ab-rounded-md ab-bg-disabled ab-w-80 ab-h-80"></div>
-    <span>md: 64〜480px に収まる範囲のものに主に使います</span>
-  </div>
-  <div class="ab-flex ab-gap-2">
-    <div class="ab-border ab-rounded-lg ab-bg-disabled ab-w-120 ab-h-120"></div>
-    <span>lg: 480px 以上のものに主に使います</span>
+  <div class="ab-flex ab-flex-column ab-gap-8">
+    <p class="ab-text-headline-s">border-radius の方向は以下を参考に</p>
+    <div class="ab-flex ab-gap-2">
+      <div class="ab-border ab-rounded-t-sm ab-bg-disabled ab-w-32 ab-h-32"></div>
+      <span>rounded-t: 上のみ</span>
+    </div>
+    <div class="ab-flex ab-gap-2">
+      <div class="ab-border ab-rounded-r-sm ab-bg-disabled ab-w-32 ab-h-32"></div>
+      <span>rounded-r: 右のみ</span>
+    </div>
+    <div class="ab-flex ab-gap-2">
+      <div class="ab-border ab-rounded-b-sm ab-bg-disabled ab-w-32 ab-h-32"></div>
+      <span>rounded-b: 下のみ</span>
+    </div>
+    <div class="ab-flex ab-gap-2">
+      <div class="ab-border ab-rounded-l-sm ab-bg-disabled ab-w-32 ab-h-32"></div>
+      <span>rounded-l: 左のみ</span>
+    </div>
+    <div class="ab-flex ab-gap-2">
+      <div class="ab-border ab-rounded-tr-sm ab-bg-disabled ab-w-32 ab-h-32"></div>
+      <span>rounded-tr: 右上のみ</span>
+    </div>
+    <div class="ab-flex ab-gap-2">
+      <div class="ab-border ab-rounded-br-sm ab-bg-disabled ab-w-32 ab-h-32"></div>
+      <span>rounded-br: 右下のみ</span>
+    </div>
+    <div class="ab-flex ab-gap-2">
+      <div class="ab-border ab-rounded-bl-sm ab-bg-disabled ab-w-32 ab-h-32"></div>
+      <span>rounded-bl: 右下のみ</span>
+    </div>
+    <div class="ab-flex ab-gap-2">
+      <div class="ab-border ab-rounded-tl-sm ab-bg-disabled ab-w-32 ab-h-32"></div>
+      <span>rounded-tl: 左上のみ</span>
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
## 概要

* border-radius utility で方向指定を可能にした

## スクリーンショット

<img width="712" alt="スクリーンショット 2024-08-02 14 07 36" src="https://github.com/user-attachments/assets/fac001aa-99f0-48fc-a8e7-7445cbbcd840">

## ユーザ影響

* なし
