### PR TITLE
[React] theme ごとの background color を storybook に追加

### DIFF
--- a/packages/react/.storybook/preview.ts
+++ b/packages/react/.storybook/preview.ts
@@ -2,6 +2,12 @@ import type { Preview } from '@storybook/react';
 import '@giftee/abukuma-css';
 
 const preview: Preview = {
+  beforeEach: () => {
+    const stories = document.getElementsByClassName('docs-story');
+    for (const story of stories) {
+      story?.setAttribute('class', 'ab-bg-base');
+    }
+  },
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {
@@ -9,6 +15,19 @@ const preview: Preview = {
         color: /(background|color)$/i,
         date: /Date$/,
       },
+    },
+    backgrounds: {
+      default: 'g4b-light',
+      values: [
+        {
+          name: 'g4b-light',
+          value: '#f6f7f8',
+        },
+        {
+          name: 'skeleton-light',
+          value: '#f6f7f8',
+        },
+      ],
     },
   },
 };


### PR DESCRIPTION
## 概要

* デザインシステムは特定の背景色を base にして作成されている
* そのため、storybook 上にもその背景色を反映するようにする

## スクリーンショット


## ユーザ影響

* なし
