### PR TITLE
[デザイントークン] g4b-dark の theme を追加

### DIFF
--- a/.changeset/nasty-starfishes-melt.md
+++ b/.changeset/nasty-starfishes-melt.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-design-tokens": patch
+---
+
+[add:theme] g4b-dark を theme に追加

--- a/packages/designTokens/DEVELOP.md
+++ b/packages/designTokens/DEVELOP.md
@@ -32,6 +32,7 @@ Generate した JSON は以下のようになっています。それらを以�
 
 - global.base.tokens.json → `tokens/globals/index.tokens.json`
 - semantic-theme.g4b-light.tokens.json → `tokens/semantics/brands/g4b-light/index.tokens.json`
+- semantic-theme.g4b-dark.tokens.json → `tokens/semantics/brands/g4b-dark/index.tokens.json`
 - semantic-theme.skeleton-light.tokens.json → `tokens/semantics/brands/skeleton-light/index.tokens.json`
 - semantic-common.base.tokens.json → `tokens/semantics/common/index.tokens.json`
 
@@ -53,9 +54,22 @@ Generate した JSON は以下のようになっています。それらを以�
   "semantic": {
     "color": {
       "text": {
-        "disable": {
+        "default": {
           "$type": "color",
           "$value": "{global.color.steel.600}"
+        }
+      }
+    }
+  }
+}
+/* semantic-theme.g4b-dark.tokens.json */
+{
+  "semantic": {
+    "color": {
+      "text": {
+        "default": {
+          "$type": "color",
+          "$value": "{global.color.white.800}"
         }
       }
     }
@@ -66,9 +80,9 @@ Generate した JSON は以下のようになっています。それらを以�
   "semantic": {
     "color": {
       "text": {
-        "disable": {
+        "default": {
           "$type": "color",
-          "$value": "{global.color.white.800}"
+          "$value": "{global.color.slate.600}"
         }
       }
     }

--- a/packages/designTokens/README.md
+++ b/packages/designTokens/README.md
@@ -10,7 +10,7 @@ $ npm install @giftee/abukuma-design-tokens
 
 ## テーマ
 
-現在、g4b-light と skeleton-light を提供しています。テーマ設定の方法は言語ごとに違います。
+現在、g4b-light, g4b-dark, skeleton-light を提供しています。テーマ設定の方法は言語ごとに違います。
 
 ## 使い方
 

--- a/packages/designTokens/build.js
+++ b/packages/designTokens/build.js
@@ -163,7 +163,7 @@ ${dictionary.allTokens
 console.log("Build started...");
 
 const DEFAULT_BRAND = "g4b-light";
-const NOT_DEFAULT_BRANDS = ["skeleton-light"];
+const NOT_DEFAULT_BRANDS = ["g4b-dark", "skeleton-light"];
 const BRANDS = [DEFAULT_BRAND, ...NOT_DEFAULT_BRANDS];
 
 BRANDS.map((brand) => {

--- a/packages/designTokens/tokens/semantics/brands/g4b-dark/index.tokens.json
+++ b/packages/designTokens/tokens/semantics/brands/g4b-dark/index.tokens.json
@@ -1,0 +1,218 @@
+{
+  "semantic": {
+    "color": {
+      "brand": {
+        "dark": {
+          "$type": "color",
+          "$value": "{global.color.marine.800}"
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{global.color.marine.600}"
+        },
+        "light": {
+          "$type": "color",
+          "$value": "{global.color.marine.400}"
+        },
+        "lighter": {
+          "$type": "color",
+          "$value": "{global.color.marine.200}"
+        },
+        "lightest": {
+          "$type": "color",
+          "$value": "{global.color.marine.50}"
+        }
+      },
+      "background": {
+        "brand-primary": {
+          "$type": "color",
+          "$value": "{semantic.color.brand.default}"
+        },
+        "brand-secondary": {
+          "$type": "color",
+          "$value": "{semantic.color.brand.dark}"
+        },
+        "disabled": {
+          "$type": "color",
+          "$value": "{global.color.slate.600}"
+        },
+        "base": {
+          "$type": "color",
+          "$value": "{global.color.steel.900}"
+        },
+        "rest-primary": {
+          "$type": "color",
+          "$value": "{global.color.steel.800}"
+        },
+        "rest-secondary": {
+          "$type": "color",
+          "$value": "{global.color.steel.600}"
+        },
+        "rest-accent": {
+          "$type": "color",
+          "$value": "{semantic.color.background.brand-secondary}"
+        },
+        "positive-primary": {
+          "$type": "color",
+          "$value": "{global.color.green.600}"
+        },
+        "positive-secondary": {
+          "$type": "color",
+          "$value": "{global.color.steel.800}"
+        },
+        "negative-primary": {
+          "$type": "color",
+          "$value": "{global.color.red.800}"
+        },
+        "negative-secondary": {
+          "$type": "color",
+          "$value": "{global.color.steel.800}"
+        },
+        "notice-primary": {
+          "$type": "color",
+          "$value": "{global.color.red.600}"
+        },
+        "notice-secondary": {
+          "$type": "color",
+          "$value": "{global.color.steel.800}"
+        },
+        "info-primary": {
+          "$type": "color",
+          "$value": "{global.color.blue.600}"
+        },
+        "info-secondary": {
+          "$type": "color",
+          "$value": "{global.color.steel.800}"
+        },
+        "hover-on-brand": {
+          "$type": "color",
+          "$value": "{semantic.color.brand.light}"
+        },
+        "focus-on-brand": {
+          "$type": "color",
+          "$value": "{semantic.color.brand.light}"
+        },
+        "pressed-on-brand": {
+          "$type": "color",
+          "$value": "{semantic.color.brand.lighter}"
+        },
+        "hover-on-neutral": {
+          "$type": "color",
+          "$value": "{global.color.marine.900}"
+        },
+        "focus-on-neutral": {
+          "$type": "color",
+          "$value": "{global.color.marine.900}"
+        },
+        "pressed-on-neutral": {
+          "$type": "color",
+          "$value": "{global.color.marine.800}"
+        },
+        "hover-on-negative": {
+          "$type": "color",
+          "$value": "{global.color.red.900}"
+        },
+        "focus-on-negative": {
+          "$type": "color",
+          "$value": "{global.color.red.900}"
+        },
+        "pressed-on-negative": {
+          "$type": "color",
+          "$value": "{global.color.red.900}"
+        },
+        "neutral-primary": {
+          "$type": "color",
+          "$value": "{global.color.steel.800}"
+        },
+        "neutral-secondary": {
+          "$type": "color",
+          "$value": "{global.color.steel.800}"
+        },
+        "overlay": {
+          "$type": "color",
+          "$value": "{global.color.transparency.slate.70}"
+        }
+      },
+      "border": {
+        "brand": {
+          "$type": "color",
+          "$value": "{semantic.color.brand.default}"
+        },
+        "bold": {
+          "$type": "color",
+          "$value": "{global.color.steel.400}"
+        },
+        "light": {
+          "$type": "color",
+          "$value": "{global.color.steel.600}"
+        },
+        "info": {
+          "$type": "color",
+          "$value": "{global.color.blue.600}"
+        },
+        "notice": {
+          "$type": "color",
+          "$value": "{global.color.red.600}"
+        },
+        "positive": {
+          "$type": "color",
+          "$value": "{global.color.green.600}"
+        },
+        "negative": {
+          "$type": "color",
+          "$value": "{global.color.red.800}"
+        },
+        "neutral": {
+          "$type": "color",
+          "$value": "{global.color.slate.400}"
+        },
+        "disable": {
+          "$type": "color",
+          "$value": "{global.color.slate.400}"
+        }
+      },
+      "text": {
+        "default": {
+          "$type": "color",
+          "$value": "{global.color.white.800}"
+        },
+        "secondary": {
+          "$type": "color",
+          "$value": "{global.color.steel.200}"
+        },
+        "brand": {
+          "$type": "color",
+          "$value": "{semantic.color.brand.light}"
+        },
+        "brand-secondary": {
+          "$type": "color",
+          "$value": "{semantic.color.brand.light}"
+        },
+        "info": {
+          "$type": "color",
+          "$value": "{global.color.blue.600}"
+        },
+        "notice": {
+          "$type": "color",
+          "$value": "{global.color.red.600}"
+        },
+        "positive": {
+          "$type": "color",
+          "$value": "{global.color.green.600}"
+        },
+        "negative": {
+          "$type": "color",
+          "$value": "{global.color.red.800}"
+        },
+        "contrast": {
+          "$type": "color",
+          "$value": "{global.color.white.800}"
+        },
+        "disable": {
+          "$type": "color",
+          "$value": "{global.color.slate.400}"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 概要

* g4b-dark の theme を追加し、g4b-light のダークモードを利用できるようにする

## スクリーンショット


## ユーザ影響

* なし
