### PR TITLE
tdタグに適用されているborder-radiusをborder-xxx-yyy-radiusのように上下左右が指定されたプロパティの利用に変更する

### DIFF
--- a/.changeset/old-wasps-serve.md
+++ b/.changeset/old-wasps-serve.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": minor
+---
+
+[fix:tabel]1セルのみ表示するとき、左側のborder-radiusが適用されない問題の修正

--- a/packages/css/src/components/table/index.scss
+++ b/packages/css/src/components/table/index.scss
@@ -21,13 +21,13 @@
       border-bottom: none;
 
       & td:first-child {
-        border-radius: var(--ab-semantic-border-radius-md) 0 0
-          var(--ab-semantic-border-radius-md);
+        border-top-left-radius: var(--ab-semantic-border-radius-md);
+        border-bottom-left-radius: var(--ab-semantic-border-radius-md);
       }
 
       & td:last-child {
-        border-radius: 0 var(--ab-semantic-border-radius-md)
-          var(--ab-semantic-border-radius-md) 0;
+        border-top-right-radius: var(--ab-semantic-border-radius-md);
+        border-bottom-right-radius: var(--ab-semantic-border-radius-md);
       }
     }
   }


### PR DESCRIPTION
## 概要

tdタグに適用されているborder-radiusをborder-xxx-yyy-radiusのように上下左右が指定されたプロパティの利用に変更する

## スクリーンショット
### 修正後

![image](https://github.com/user-attachments/assets/2431a05c-dcd3-4745-b6da-78b23ac95c3b)

- 行の左側に16pxのborder-raidusが当たっていることを確認

## ユーザ影響

なし