### PR TITLE
[css] fix: GridTable に aria-label を追加

### DIFF
--- a/packages/css/src/components/gridtable/stories/Base.stories.ts
+++ b/packages/css/src/components/gridtable/stories/Base.stories.ts
@@ -12,7 +12,7 @@ export const Base: Story = {
     return `
 <div>
   <!-- 「style="--ab-gridtable-columns-count: 5;"」のように、テーブルの列数を指定する必要がある -->
-  <div class="ab-Gridtable" role="table" style="--ab-gridtable-columns-count: 5;">
+  <div class="ab-Gridtable" role="table" aria-label="商品一覧" style="--ab-gridtable-columns-count: 5;">
     <div class="ab-Gridtable-head" role="rowgroup">
       <div class="ab-Gridtable-head-cell" role="columnheader">商品情報</div>
       <div class="ab-Gridtable-head-cell" role="columnheader">価格</div>
@@ -82,7 +82,7 @@ export const Base: Story = {
   </div>
 
 
-  <div class="ab-Gridtable" role="table" style="--ab-gridtable-columns-count: 4;">
+  <div class="ab-Gridtable" role="table" aria-label="ギフトのお申し込み内容" style="--ab-gridtable-columns-count: 4;">
     <div class="ab-Gridtable-head" role="rowgroup">
       <div class="ab-Gridtable-head-cell" role="columnheader">商品情報</div>
       <div class="ab-Gridtable-head-cell" role="columnheader">価格</div>

--- a/packages/css/src/components/gridtable/stories/Bordered.stories.ts
+++ b/packages/css/src/components/gridtable/stories/Bordered.stories.ts
@@ -11,7 +11,7 @@ export const Bordered: Story = {
   render: (_args) => {
     return `
 <!-- 「class="ab-Gridtable-bordered"」を追加している -->
-<div class="ab-Gridtable ab-Gridtable-bordered" role="table" style="--ab-gridtable-columns-count: 5;">
+<div class="ab-Gridtable ab-Gridtable-bordered" role="table" aria-label="商品一覧" style="--ab-gridtable-columns-count: 5;">
   <div class="ab-Gridtable-head" role="rowgroup">
     <div class="ab-Gridtable-head-cell" role="columnheader">商品情報</div>
     <div class="ab-Gridtable-head-cell" role="columnheader">価格</div>

--- a/packages/css/src/components/gridtable/stories/Select.stories.ts
+++ b/packages/css/src/components/gridtable/stories/Select.stories.ts
@@ -11,7 +11,7 @@ export const Select: Story = {
   render: (_args) => {
     return `
 <!-- 「class="ab-Gridtable-select"」を追加している -->
-<div class="ab-Gridtable ab-Gridtable-select" role="table" style="--ab-gridtable-columns-count: 5;">
+<div class="ab-Gridtable ab-Gridtable-select" role="table" aria-label="商品一覧" style="--ab-gridtable-columns-count: 5;">
   <div class="ab-Gridtable-head" role="rowgroup">
     <div class="ab-Gridtable-head-cell" role="columnheader">商品情報</div>
     <div class="ab-Gridtable-head-cell" role="columnheader">価格</div>


### PR DESCRIPTION
## 概要

- GridTable の StoryBook に aria-label を追加
  - 指摘の修正漏れ: https://github.com/giftee/design-system/pull/81#discussion_r1766342000
- リリースノートに載せるほどのものではないため、 Changeset 未使用

## スクリーンショット


## ユーザ影響

- なし
