### PR TITLE
[design token] g4b-dark のコントラスト比向上のため、red を微調整

### DIFF
--- a/.changeset/early-planes-relax.md
+++ b/.changeset/early-planes-relax.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-design-tokens": patch
+---
+
+[change:red] g4b-dark テーマ時の視認性を上げるために red を微調整

--- a/packages/designTokens/tokens/globals/index.tokens.json
+++ b/packages/designTokens/tokens/globals/index.tokens.json
@@ -220,19 +220,19 @@
       "red": {
         "50": {
           "$type": "color",
-          "$value": "#fff2f2"
+          "$value": "#fff4f2"
         },
         "100": {
           "$type": "color",
-          "$value": "#ffe1db"
+          "$value": "#ffe0db"
         },
         "200": {
           "$type": "color",
-          "$value": "#ffcdc3"
+          "$value": "#ffccc3"
         },
         "400": {
           "$type": "color",
-          "$value": "#ff9687"
+          "$value": "#ff9987"
         },
         "600": {
           "$type": "color",
@@ -240,11 +240,11 @@
         },
         "800": {
           "$type": "color",
-          "$value": "#eb2300"
+          "$value": "#b21b00"
         },
         "900": {
           "$type": "color",
-          "$value": "#a00a00"
+          "$value": "#731100"
         }
       },
       "blue": {

--- a/packages/designTokens/tokens/semantics/brands/g4b-dark/index.tokens.json
+++ b/packages/designTokens/tokens/semantics/brands/g4b-dark/index.tokens.json
@@ -110,15 +110,15 @@
         },
         "hover-on-negative": {
           "$type": "color",
-          "$value": "{global.color.red.900}"
+          "$value": "{global.color.red.50}"
         },
         "focus-on-negative": {
           "$type": "color",
-          "$value": "{global.color.red.900}"
+          "$value": "{global.color.red.50}"
         },
         "pressed-on-negative": {
           "$type": "color",
-          "$value": "{global.color.red.900}"
+          "$value": "{global.color.red.200}"
         },
         "neutral-primary": {
           "$type": "color",


### PR DESCRIPTION
## 概要

* g4b-dark の red を利用しているあたりでコントラスト比微妙
* そのため、red を微調整する

## スクリーンショット


## ユーザ影響

* StatusColor の negative の色が微妙に変わります（ほとんどわかりません）
