### PR TITLE
[CSS] Textfield の textarea 利用時に rows/cols が利用できるようにした

### DIFF
--- a/.changeset/rare-chairs-camp.md
+++ b/.changeset/rare-chairs-camp.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[change:Textfield] textarea 利用時に rows, cols 指定を可能とした

--- a/packages/css/src/components/textfield/index.scss
+++ b/packages/css/src/components/textfield/index.scss
@@ -65,6 +65,13 @@
     }
   }
 
+  &-textarea {
+    @extend .ab-Textfield-input;
+
+    height: auto;
+    min-height: var(--textfield-input-height);
+  }
+
   &-helptext {
     padding-top: var(--ab-semantic-spacing-1);
     font-size: $font-size-body-xs;

--- a/packages/css/src/components/textfield/stories/Resize.stories.ts
+++ b/packages/css/src/components/textfield/stories/Resize.stories.ts
@@ -19,7 +19,9 @@ export const Resize: Story = {
       id="textarea-resize-both"
       placeholder="textarea resize both"
       name="field"
-      class="ab-Textfield-input ab-h-48"
+      rows="5"
+      cols="15"
+      class="ab-Textfield-textarea"
     >
       Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
     </textarea>
@@ -33,7 +35,7 @@ export const Resize: Story = {
       id="textarea-resize-vertical"
       placeholder="textarea resize vertical"
       name="field"
-      class="ab-Textfield-input ab-h-48"
+      class="ab-Textfield-textarea"
     >
       Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
     </textarea>
@@ -47,7 +49,7 @@ export const Resize: Story = {
       id="textarea-resize-horizontal"
       placeholder="textarea resize horizontal"
       name="field"
-      class="ab-Textfield-input ab-h-48"
+      class="ab-Textfield-textarea"
     >
       Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
     </textarea>

--- a/packages/css/src/components/textfield/stories/Type.stories.ts
+++ b/packages/css/src/components/textfield/stories/Type.stories.ts
@@ -25,15 +25,19 @@ export const Type: Story = {
   </div>
   <div class="ab-Textfield ab-mb-8">
     <label for="textarea" class="ab-Textfield-label">
-      テキストエリア
+      テキストエリア。rows と cols を指定可能です。
       ${args.required ? `<div class="ab-StatusLabel">必須</div>` : ''}
     </label>
     <textarea
       id="textarea"
       placeholder="textarea"
       name="field"
-      class="ab-Textfield-input"
-    ></textarea>
+      class="ab-Textfield-textarea"
+      rows="5"
+      cols="15"
+    >
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+    </textarea>
     <div class="ab-Textfield-helptext">textarea の Textfield</div>
   </div>
 </div>


### PR DESCRIPTION
## 概要

* Textfield の`ab-Textfield-input` クラスは height が固定されている
* そのため、textarea 利用時に rows/cols を指定しても反映されない問題があった
* そこで、textarea 利用時は `ab-Textfield-input` を利用するようにして、rows/cols を利用できるようにする

## スクリーンショット

* 見た目は変わらない

## ユーザ影響

* textarea 利用時は `ab-Textfield-input` => `ab-Textfield-input` に変更してください
    * また、height を上書き指定してる場合は rows の利用を検討してください
