### PR TITLE
[React] Textfield に textarea 利用のプロパティを追加

### DIFF
--- a/.changeset/fuzzy-plants-admire.md
+++ b/.changeset/fuzzy-plants-admire.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-react": patch
+---
+
+[add:Textfield] textarea を指定可能とした

--- a/packages/react/src/components/textfield/Index.tsx
+++ b/packages/react/src/components/textfield/Index.tsx
@@ -3,13 +3,19 @@ import { StatusLabel } from '@/index';
 import { classNames } from '@/utils/classNames';
 import type { ComponentPropsWithoutRef, ElementRef } from 'react';
 
-export type TextfieldProps = ComponentPropsWithoutRef<'input'> & {
-  label?: string;
-  helptext?: string;
-  error?: boolean;
-};
+export type TextfieldProps = ComponentPropsWithoutRef<'input'> &
+  ComponentPropsWithoutRef<'textarea'> & {
+    label?: string;
+    helptext?: string;
+    error?: boolean;
+    multiline?: number;
+    resize?: 'vertical' | 'horizontal' | 'both' | 'none';
+  };
 
-export const Textfield = forwardRef<ElementRef<'input'>, TextfieldProps>(
+export const Textfield = forwardRef<
+  ElementRef<'input'> & ElementRef<'textarea'>,
+  TextfieldProps
+>(
   (
     {
       label,
@@ -18,6 +24,8 @@ export const Textfield = forwardRef<ElementRef<'input'>, TextfieldProps>(
       name,
       required,
       disabled,
+      multiline,
+      resize = 'none',
       children,
       className,
       ...rest
@@ -28,6 +36,13 @@ export const Textfield = forwardRef<ElementRef<'input'>, TextfieldProps>(
       'ab-Textfield',
       error && 'is-error',
       disabled && 'is-disabled',
+      resize === 'both'
+        ? 'resize-both'
+        : resize === 'horizontal'
+          ? 'resize-horizontal'
+          : resize === 'vertical'
+            ? 'resize-vertical'
+            : '',
       className,
     );
 
@@ -39,14 +54,26 @@ export const Textfield = forwardRef<ElementRef<'input'>, TextfieldProps>(
             {required && <StatusLabel variant="primary">必須</StatusLabel>}
           </label>
         )}
-        <input
-          id={name}
-          name={name}
-          className="ab-Textfield-input"
-          ref={forwardedRef}
-          required={required}
-          {...rest}
-        />
+        {!multiline ? (
+          <input
+            id={name}
+            name={name}
+            className="ab-Textfield-input"
+            ref={forwardedRef}
+            required={required}
+            {...rest}
+          />
+        ) : (
+          <textarea
+            id={name}
+            name={name}
+            className="ab-Textfield-textarea"
+            ref={forwardedRef}
+            required={required}
+            rows={multiline}
+            {...rest}
+          />
+        )}
         {!!helptext && <div className="ab-Textfield-helptext">{helptext}</div>}
       </div>
     );

--- a/packages/react/src/components/textfield/Textfield.stories.tsx
+++ b/packages/react/src/components/textfield/Textfield.stories.tsx
@@ -12,6 +12,8 @@ const meta = {
     error: false,
     required: false,
     disabled: false,
+    multiline: undefined,
+    resize: 'none',
   },
   argTypes: {
     label: {
@@ -59,6 +61,15 @@ const meta = {
       },
       description: '非活性',
     },
+    multiline: {
+      control: { type: 'number' },
+      table: {
+        defaultValue: {
+          summary: undefined,
+        },
+      },
+      description: 'テキストエリアデフォルト行数',
+    },
   },
 } satisfies Meta<typeof Textfield>;
 
@@ -68,6 +79,45 @@ type Story = StoryObj<typeof meta>;
 export const Base: Story = {
   render: ({ ...args }: TextfieldProps) => (
     <Textfield name="base" {...args}></Textfield>
+  ),
+};
+
+export const Type: Story = {
+  render: ({ ...args }: TextfieldProps) => (
+    <>
+      <div className="ab-flex ab-flex-column ab-gap-12">
+        <Textfield name="input" {...args} label="input"></Textfield>
+        <Textfield
+          name="textarea"
+          {...args}
+          label="textarea"
+          multiline={5}
+          helptext="multilineの指定でテキストエリアになります"
+        ></Textfield>
+        <Textfield
+          name="textarea-resize-both"
+          {...args}
+          label="textarea-resize-both"
+          multiline={5}
+          resize="both"
+          helptext="multilineとresizeを組み合わせることで、サイズ可変のテキストエリアになります"
+        ></Textfield>
+        <Textfield
+          name="textarea-resize-horizontal"
+          {...args}
+          label="textarea-resize-horizontal"
+          multiline={5}
+          resize="horizontal"
+        ></Textfield>
+        <Textfield
+          name="textarea-resize-vertical"
+          {...args}
+          label="textarea-resize-vertical"
+          multiline={5}
+          resize="vertical"
+        ></Textfield>
+      </div>
+    </>
   ),
 };
 


### PR DESCRIPTION
## 概要

* Textfield に textarea 利用のプロパティがなかった
* そこで、`multiline` プロパティを追加し、それがあれば textarea としてレンダリングするようにした
* また、resize 用のプロパティも追加

## スクリーンショット

* 見た目は CSS と一緒

## ユーザ影響

* 機能追加
