### PR TITLE
[CSS] Gridtable を GridTable にリネーム

### DIFF
--- a/.changeset/rude-spies-reply.md
+++ b/.changeset/rude-spies-reply.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[change:Gridtable] クラス名を Gridtable から GridTable に変更

--- a/packages/css/src/components/gridtable/index.scss
+++ b/packages/css/src/components/gridtable/index.scss
@@ -1,4 +1,4 @@
-.ab-Gridtable {
+.ab-GridTable {
   width: 100%;
   font-size: $font-size-body-s;
   display: grid;
@@ -68,14 +68,14 @@
   }
 }
 
-.ab-Gridtable-bordered {
-  & .ab-Gridtable-rowgroup {
+.ab-GridTable-bordered {
+  & .ab-GridTable-rowgroup {
     border: $border;
   }
 }
 
-.ab-Gridtable-select {
-  & .ab-Gridtable-rowgroup {
+.ab-GridTable-select {
+  & .ab-GridTable-rowgroup {
     @include hover {
       background-color: var(--ab-semantic-color-background-brand-secondary);
       cursor: pointer;

--- a/packages/css/src/components/gridtable/stories/Base.stories.ts
+++ b/packages/css/src/components/gridtable/stories/Base.stories.ts
@@ -12,34 +12,34 @@ export const Base: Story = {
     return `
 <div>
   <!-- 「style="--ab-gridtable-columns-count: 5;"」のように、テーブルの列数を指定する必要がある -->
-  <div class="ab-Gridtable" role="table" aria-label="商品一覧" style="--ab-gridtable-columns-count: 5;">
-    <div class="ab-Gridtable-head" role="rowgroup">
-      <div class="ab-Gridtable-head-cell" role="columnheader">商品情報</div>
-      <div class="ab-Gridtable-head-cell" role="columnheader">価格</div>
-      <div class="ab-Gridtable-head-cell" role="columnheader">ギフト利用審査</div>
-      <div class="ab-Gridtable-head-cell" role="columnheader">最低発注数有無</div>
-      <div class="ab-Gridtable-head-cell" role="columnheader">有効期限</div>
+  <div class="ab-GridTable" role="table" aria-label="商品一覧" style="--ab-gridtable-columns-count: 5;">
+    <div class="ab-GridTable-head" role="rowgroup">
+      <div class="ab-GridTable-head-cell" role="columnheader">商品情報</div>
+      <div class="ab-GridTable-head-cell" role="columnheader">価格</div>
+      <div class="ab-GridTable-head-cell" role="columnheader">ギフト利用審査</div>
+      <div class="ab-GridTable-head-cell" role="columnheader">最低発注数有無</div>
+      <div class="ab-GridTable-head-cell" role="columnheader">有効期限</div>
     </div>
 
-    <div class="ab-Gridtable-body" role="rowgroup">
-      <div class="ab-Gridtable-rowgroup" role="rowgroup">
-        <div class="ab-Gridtable-row" role="row">
-          <div class="ab-Gridtable-cell" role="cell">
+    <div class="ab-GridTable-body" role="rowgroup">
+      <div class="ab-GridTable-rowgroup" role="rowgroup">
+        <div class="ab-GridTable-row" role="row">
+          <div class="ab-GridTable-cell" role="cell">
             <div class="ab-flex ab-flex-column">
               <span class="ab-text-body-xs ab-text-secondary">ギフティ</span>
               <span class="ab-text-body-s">giftee Box</span>
             </div>
           </div>
-          <div class="ab-Gridtable-cell" role="cell">¥500</div>
-          <div class="ab-Gridtable-cell" role="cell">1〜2営業日</div>
-          <div class="ab-Gridtable-cell" role="cell">あり</div>
-          <div class="ab-Gridtable-cell" role="cell">１ヶ月後の月末</div>
+          <div class="ab-GridTable-cell" role="cell">¥500</div>
+          <div class="ab-GridTable-cell" role="cell">1〜2営業日</div>
+          <div class="ab-GridTable-cell" role="cell">あり</div>
+          <div class="ab-GridTable-cell" role="cell">１ヶ月後の月末</div>
         </div>
       </div>
 
-      <div class="ab-Gridtable-rowgroup" role="rowgroup">
-        <div class="ab-Gridtable-row" role="row">
-          <div class="ab-Gridtable-cell" role="cell">
+      <div class="ab-GridTable-rowgroup" role="rowgroup">
+        <div class="ab-GridTable-row" role="row">
+          <div class="ab-GridTable-cell" role="cell">
             <div class=" ab-flex ab-flex-items-center">
               <img src="${GifteeBox}" class="ab-mr-2" style="height: 56px;" />
               <div class="ab-flex ab-flex-column">
@@ -48,16 +48,16 @@ export const Base: Story = {
               </div>
             </div>
           </div>
-          <div class="ab-Gridtable-cell" role="cell">¥500</div>
-          <div class="ab-Gridtable-cell" role="cell">1〜2営業日</div>
-          <div class="ab-Gridtable-cell" role="cell">あり</div>
-          <div class="ab-Gridtable-cell" role="cell">１ヶ月後の月末</div>
+          <div class="ab-GridTable-cell" role="cell">¥500</div>
+          <div class="ab-GridTable-cell" role="cell">1〜2営業日</div>
+          <div class="ab-GridTable-cell" role="cell">あり</div>
+          <div class="ab-GridTable-cell" role="cell">１ヶ月後の月末</div>
         </div>
       </div>
 
-      <div class="ab-Gridtable-rowgroup" role="rowgroup">
-        <div class="ab-Gridtable-row" role="row">
-          <div class="ab-Gridtable-cell" role="cell">
+      <div class="ab-GridTable-rowgroup" role="rowgroup">
+        <div class="ab-GridTable-row" role="row">
+          <div class="ab-GridTable-cell" role="cell">
             <div class="ab-flex ab-flex-items-center">
               <div class="ab-Checkbox-wrapper ab-mr-2">
                 <div class="ab-Checkbox">
@@ -72,49 +72,49 @@ export const Base: Story = {
               </div>
             </div>
           </div>
-          <div class="ab-Gridtable-cell" role="cell">¥500</div>
-          <div class="ab-Gridtable-cell" role="cell">1〜2営業日</div>
-          <div class="ab-Gridtable-cell" role="cell">あり</div>
-          <div class="ab-Gridtable-cell" role="cell">１ヶ月後の月末</div>
+          <div class="ab-GridTable-cell" role="cell">¥500</div>
+          <div class="ab-GridTable-cell" role="cell">1〜2営業日</div>
+          <div class="ab-GridTable-cell" role="cell">あり</div>
+          <div class="ab-GridTable-cell" role="cell">１ヶ月後の月末</div>
         </div>
       </div>
     </div>
   </div>
 
 
-  <div class="ab-Gridtable" role="table" aria-label="ギフトのお申し込み内容" style="--ab-gridtable-columns-count: 4;">
-    <div class="ab-Gridtable-head" role="rowgroup">
-      <div class="ab-Gridtable-head-cell" role="columnheader">商品情報</div>
-      <div class="ab-Gridtable-head-cell" role="columnheader">価格</div>
-      <div class="ab-Gridtable-head-cell" role="columnheader">数量</div>
-      <div class="ab-Gridtable-head-cell" role="columnheader">小計</div>
+  <div class="ab-GridTable" role="table" aria-label="ギフトのお申し込み内容" style="--ab-gridtable-columns-count: 4;">
+    <div class="ab-GridTable-head" role="rowgroup">
+      <div class="ab-GridTable-head-cell" role="columnheader">商品情報</div>
+      <div class="ab-GridTable-head-cell" role="columnheader">価格</div>
+      <div class="ab-GridTable-head-cell" role="columnheader">数量</div>
+      <div class="ab-GridTable-head-cell" role="columnheader">小計</div>
     </div>
 
-    <div class="ab-Gridtable-body" role="rowgroup">
-      <div class="ab-Gridtable-rowgroup" role="rowgroup">
-        <div class="ab-Gridtable-row" role="row">
+    <div class="ab-GridTable-body" role="rowgroup">
+      <div class="ab-GridTable-rowgroup" role="rowgroup">
+        <div class="ab-GridTable-row" role="row">
           <!-- 「style="--ab-gridtable-cell-rowspan: 2;"」のように指定すると、縦に2行分のサイズになる -->
-          <div class="ab-Gridtable-cell" role="cell" style="--ab-gridtable-cell-rowspan: 2;">
+          <div class="ab-GridTable-cell" role="cell" style="--ab-gridtable-cell-rowspan: 2;">
             <div class="ab-flex ab-flex-column">
               <span class="ab-text-body-xs ab-text-secondary">ギフティ</span>
               <span class="ab-text-body-s">giftee Box</span>
             </div>
           </div>
-          <div class="ab-Gridtable-cell ab-Gridtable-cell-border" role="cell">¥100</div>
-          <div class="ab-Gridtable-cell ab-Gridtable-cell-border" role="cell">10</div>
-          <div class="ab-Gridtable-cell ab-Gridtable-cell-border" role="cell">¥1,000</div>
+          <div class="ab-GridTable-cell ab-GridTable-cell-border" role="cell">¥100</div>
+          <div class="ab-GridTable-cell ab-GridTable-cell-border" role="cell">10</div>
+          <div class="ab-GridTable-cell ab-GridTable-cell-border" role="cell">¥1,000</div>
         </div>
 
-        <div class="ab-Gridtable-row" role="row">
-          <div class="ab-Gridtable-cell ab-Gridtable-cell-border" role="cell">¥200</div>
-          <div class="ab-Gridtable-cell ab-Gridtable-cell-border" role="cell">30</div>
-          <div class="ab-Gridtable-cell ab-Gridtable-cell-border" role="cell">¥6,000</div>
+        <div class="ab-GridTable-row" role="row">
+          <div class="ab-GridTable-cell ab-GridTable-cell-border" role="cell">¥200</div>
+          <div class="ab-GridTable-cell ab-GridTable-cell-border" role="cell">30</div>
+          <div class="ab-GridTable-cell ab-GridTable-cell-border" role="cell">¥6,000</div>
         </div>
       </div>
 
-      <div class="ab-Gridtable-rowgroup" role="rowgroup">
-        <div class="ab-Gridtable-row" role="row">
-          <div class="ab-Gridtable-cell" role="cell">
+      <div class="ab-GridTable-rowgroup" role="rowgroup">
+        <div class="ab-GridTable-row" role="row">
+          <div class="ab-GridTable-cell" role="cell">
             <div class="ab-flex ab-flex-items-center">
               <img src="${GifteeBox}" class="ab-mx-2" style="height: 56px;" />
               <div class="ab-flex ab-flex-column">
@@ -123,28 +123,28 @@ export const Base: Story = {
               </div>
             </div>
           </div>
-          <div class="ab-Gridtable-cell" role="cell">¥500</div>
-          <div class="ab-Gridtable-cell" role="cell">50</div>
-          <div class="ab-Gridtable-cell" role="cell">¥25,000</div>
+          <div class="ab-GridTable-cell" role="cell">¥500</div>
+          <div class="ab-GridTable-cell" role="cell">50</div>
+          <div class="ab-GridTable-cell" role="cell">¥25,000</div>
         </div>
       </div>
 
       <!-- 「style="--ab-gridtable-column-start: 3;"」で3列目からの配置になる -->
       <!-- 「style="--ab-gridtable-column-end: 5;"」で5列目までの配置になる -->
-      <div class="ab-Gridtable-rowgroup" role="rowgroup" style="--ab-gridtable-column-start: 3; --ab-gridtable-column-end: 5;">
-        <div class="ab-Gridtable-row" role="row">
-          <div class="ab-Gridtable-cell" role="cell">商品代合計</div>
-          <div class="ab-Gridtable-cell" role="cell">¥32,000</div>
+      <div class="ab-GridTable-rowgroup" role="rowgroup" style="--ab-gridtable-column-start: 3; --ab-gridtable-column-end: 5;">
+        <div class="ab-GridTable-row" role="row">
+          <div class="ab-GridTable-cell" role="cell">商品代合計</div>
+          <div class="ab-GridTable-cell" role="cell">¥32,000</div>
         </div>
 
-        <div class="ab-Gridtable-row" role="row">
-          <div class="ab-Gridtable-cell" role="cell">消費税</div>
-          <div class="ab-Gridtable-cell" role="cell">¥3,200</div>
+        <div class="ab-GridTable-row" role="row">
+          <div class="ab-GridTable-cell" role="cell">消費税</div>
+          <div class="ab-GridTable-cell" role="cell">¥3,200</div>
         </div>
 
-        <div class="ab-Gridtable-row ab-font-bold" role="row">
-          <div class="ab-Gridtable-cell" role="cell">お支払い合計</div>
-          <div class="ab-Gridtable-cell" role="cell">¥35,200</div>
+        <div class="ab-GridTable-row ab-font-bold" role="row">
+          <div class="ab-GridTable-cell" role="cell">お支払い合計</div>
+          <div class="ab-GridTable-cell" role="cell">¥35,200</div>
         </div>
 
       </div>

--- a/packages/css/src/components/gridtable/stories/Bordered.stories.ts
+++ b/packages/css/src/components/gridtable/stories/Bordered.stories.ts
@@ -10,35 +10,35 @@ export default {
 export const Bordered: Story = {
   render: (_args) => {
     return `
-<!-- 「class="ab-Gridtable-bordered"」を追加している -->
-<div class="ab-Gridtable ab-Gridtable-bordered" role="table" aria-label="商品一覧" style="--ab-gridtable-columns-count: 5;">
-  <div class="ab-Gridtable-head" role="rowgroup">
-    <div class="ab-Gridtable-head-cell" role="columnheader">商品情報</div>
-    <div class="ab-Gridtable-head-cell" role="columnheader">価格</div>
-    <div class="ab-Gridtable-head-cell" role="columnheader">ギフト利用審査</div>
-    <div class="ab-Gridtable-head-cell" role="columnheader">最低発注数有無</div>
-    <div class="ab-Gridtable-head-cell" role="columnheader">有効期限</div>
+<!-- 「class="ab-GridTable-bordered"」を追加している -->
+<div class="ab-GridTable ab-GridTable-bordered" role="table" aria-label="商品一覧" style="--ab-gridtable-columns-count: 5;">
+  <div class="ab-GridTable-head" role="rowgroup">
+    <div class="ab-GridTable-head-cell" role="columnheader">商品情報</div>
+    <div class="ab-GridTable-head-cell" role="columnheader">価格</div>
+    <div class="ab-GridTable-head-cell" role="columnheader">ギフト利用審査</div>
+    <div class="ab-GridTable-head-cell" role="columnheader">最低発注数有無</div>
+    <div class="ab-GridTable-head-cell" role="columnheader">有効期限</div>
   </div>
 
-  <div class="ab-Gridtable-body" role="rowgroup">
-    <div class="ab-Gridtable-rowgroup" role="rowgroup">
-      <div class="ab-Gridtable-row" role="row">
-        <div class="ab-Gridtable-cell" role="cell">
+  <div class="ab-GridTable-body" role="rowgroup">
+    <div class="ab-GridTable-rowgroup" role="rowgroup">
+      <div class="ab-GridTable-row" role="row">
+        <div class="ab-GridTable-cell" role="cell">
           <div class="ab-flex ab-flex-column">
             <span class="ab-text-body-xs ab-text-secondary">ギフティ</span>
             <span class="ab-text-body-s">giftee Box</span>
           </div>
         </div>
-        <div class="ab-Gridtable-cell" role="cell">¥500</div>
-        <div class="ab-Gridtable-cell" role="cell">1〜2営業日</div>
-        <div class="ab-Gridtable-cell" role="cell">あり</div>
-        <div class="ab-Gridtable-cell" role="cell">１ヶ月後の月末</div>
+        <div class="ab-GridTable-cell" role="cell">¥500</div>
+        <div class="ab-GridTable-cell" role="cell">1〜2営業日</div>
+        <div class="ab-GridTable-cell" role="cell">あり</div>
+        <div class="ab-GridTable-cell" role="cell">１ヶ月後の月末</div>
       </div>
     </div>
 
-    <div class="ab-Gridtable-rowgroup" role="rowgroup">
-      <div class="ab-Gridtable-row" role="row">
-        <div class="ab-Gridtable-cell" role="cell">
+    <div class="ab-GridTable-rowgroup" role="rowgroup">
+      <div class="ab-GridTable-row" role="row">
+        <div class="ab-GridTable-cell" role="cell">
           <div class=" ab-flex ab-flex-items-center">
             <img src="${GifteeBox}" class="ab-mr-2" style="height: 56px;" />
             <div class="ab-flex ab-flex-column">
@@ -47,16 +47,16 @@ export const Bordered: Story = {
             </div>
           </div>
         </div>
-        <div class="ab-Gridtable-cell" role="cell">¥500</div>
-        <div class="ab-Gridtable-cell" role="cell">1〜2営業日</div>
-        <div class="ab-Gridtable-cell" role="cell">あり</div>
-        <div class="ab-Gridtable-cell" role="cell">１ヶ月後の月末</div>
+        <div class="ab-GridTable-cell" role="cell">¥500</div>
+        <div class="ab-GridTable-cell" role="cell">1〜2営業日</div>
+        <div class="ab-GridTable-cell" role="cell">あり</div>
+        <div class="ab-GridTable-cell" role="cell">１ヶ月後の月末</div>
       </div>
     </div>
 
-    <div class="ab-Gridtable-rowgroup" role="rowgroup">
-      <div class="ab-Gridtable-row" role="row">
-        <div class="ab-Gridtable-cell" role="cell">
+    <div class="ab-GridTable-rowgroup" role="rowgroup">
+      <div class="ab-GridTable-row" role="row">
+        <div class="ab-GridTable-cell" role="cell">
           <div class="ab-flex ab-flex-items-center">
             <div class="ab-Checkbox-wrapper ab-mr-2">
               <div class="ab-Checkbox">
@@ -71,10 +71,10 @@ export const Bordered: Story = {
             </div>
           </div>
         </div>
-        <div class="ab-Gridtable-cell" role="cell">¥500</div>
-        <div class="ab-Gridtable-cell" role="cell">1〜2営業日</div>
-        <div class="ab-Gridtable-cell" role="cell">あり</div>
-        <div class="ab-Gridtable-cell" role="cell">１ヶ月後の月末</div>
+        <div class="ab-GridTable-cell" role="cell">¥500</div>
+        <div class="ab-GridTable-cell" role="cell">1〜2営業日</div>
+        <div class="ab-GridTable-cell" role="cell">あり</div>
+        <div class="ab-GridTable-cell" role="cell">１ヶ月後の月末</div>
       </div>
     </div>
   </div>

--- a/packages/css/src/components/gridtable/stories/Select.stories.ts
+++ b/packages/css/src/components/gridtable/stories/Select.stories.ts
@@ -10,35 +10,35 @@ export default {
 export const Select: Story = {
   render: (_args) => {
     return `
-<!-- 「class="ab-Gridtable-select"」を追加している -->
-<div class="ab-Gridtable ab-Gridtable-select" role="table" aria-label="商品一覧" style="--ab-gridtable-columns-count: 5;">
-  <div class="ab-Gridtable-head" role="rowgroup">
-    <div class="ab-Gridtable-head-cell" role="columnheader">商品情報</div>
-    <div class="ab-Gridtable-head-cell" role="columnheader">価格</div>
-    <div class="ab-Gridtable-head-cell" role="columnheader">ギフト利用審査</div>
-    <div class="ab-Gridtable-head-cell" role="columnheader">最低発注数有無</div>
-    <div class="ab-Gridtable-head-cell" role="columnheader">有効期限</div>
+<!-- 「class="ab-GridTable-select"」を追加している -->
+<div class="ab-GridTable ab-GridTable-select" role="table" aria-label="商品一覧" style="--ab-gridtable-columns-count: 5;">
+  <div class="ab-GridTable-head" role="rowgroup">
+    <div class="ab-GridTable-head-cell" role="columnheader">商品情報</div>
+    <div class="ab-GridTable-head-cell" role="columnheader">価格</div>
+    <div class="ab-GridTable-head-cell" role="columnheader">ギフト利用審査</div>
+    <div class="ab-GridTable-head-cell" role="columnheader">最低発注数有無</div>
+    <div class="ab-GridTable-head-cell" role="columnheader">有効期限</div>
   </div>
 
-  <div class="ab-Gridtable-body" role="rowgroup">
-    <div class="ab-Gridtable-rowgroup" role="rowgroup">
-      <div class="ab-Gridtable-row" role="row">
-        <div class="ab-Gridtable-cell" role="cell">
+  <div class="ab-GridTable-body" role="rowgroup">
+    <div class="ab-GridTable-rowgroup" role="rowgroup">
+      <div class="ab-GridTable-row" role="row">
+        <div class="ab-GridTable-cell" role="cell">
           <div class="ab-flex ab-flex-column">
             <span class="ab-text-body-xs ab-text-secondary">ギフティ</span>
             <span class="ab-text-body-s">giftee Box</span>
           </div>
         </div>
-        <div class="ab-Gridtable-cell" role="cell">¥500</div>
-        <div class="ab-Gridtable-cell" role="cell">1〜2営業日</div>
-        <div class="ab-Gridtable-cell" role="cell">あり</div>
-        <div class="ab-Gridtable-cell" role="cell">１ヶ月後の月末</div>
+        <div class="ab-GridTable-cell" role="cell">¥500</div>
+        <div class="ab-GridTable-cell" role="cell">1〜2営業日</div>
+        <div class="ab-GridTable-cell" role="cell">あり</div>
+        <div class="ab-GridTable-cell" role="cell">１ヶ月後の月末</div>
       </div>
     </div>
 
-    <div class="ab-Gridtable-rowgroup" role="rowgroup">
-      <div class="ab-Gridtable-row" role="row">
-        <div class="ab-Gridtable-cell" role="cell">
+    <div class="ab-GridTable-rowgroup" role="rowgroup">
+      <div class="ab-GridTable-row" role="row">
+        <div class="ab-GridTable-cell" role="cell">
           <div class=" ab-flex ab-flex-items-center">
             <img src="${GifteeBox}" class="ab-mr-2" style="height: 56px;" />
             <div class="ab-flex ab-flex-column">
@@ -47,16 +47,16 @@ export const Select: Story = {
             </div>
           </div>
         </div>
-        <div class="ab-Gridtable-cell" role="cell">¥500</div>
-        <div class="ab-Gridtable-cell" role="cell">1〜2営業日</div>
-        <div class="ab-Gridtable-cell" role="cell">あり</div>
-        <div class="ab-Gridtable-cell" role="cell">１ヶ月後の月末</div>
+        <div class="ab-GridTable-cell" role="cell">¥500</div>
+        <div class="ab-GridTable-cell" role="cell">1〜2営業日</div>
+        <div class="ab-GridTable-cell" role="cell">あり</div>
+        <div class="ab-GridTable-cell" role="cell">１ヶ月後の月末</div>
       </div>
     </div>
 
-    <div class="ab-Gridtable-rowgroup" role="rowgroup">
-      <div class="ab-Gridtable-row" role="row">
-        <div class="ab-Gridtable-cell" role="cell">
+    <div class="ab-GridTable-rowgroup" role="rowgroup">
+      <div class="ab-GridTable-row" role="row">
+        <div class="ab-GridTable-cell" role="cell">
           <div class="ab-flex ab-flex-items-center">
             <div class="ab-Checkbox-wrapper ab-mr-2">
               <div class="ab-Checkbox">
@@ -71,10 +71,10 @@ export const Select: Story = {
             </div>
           </div>
         </div>
-        <div class="ab-Gridtable-cell" role="cell">¥500</div>
-        <div class="ab-Gridtable-cell" role="cell">1〜2営業日</div>
-        <div class="ab-Gridtable-cell" role="cell">あり</div>
-        <div class="ab-Gridtable-cell" role="cell">１ヶ月後の月末</div>
+        <div class="ab-GridTable-cell" role="cell">¥500</div>
+        <div class="ab-GridTable-cell" role="cell">1〜2営業日</div>
+        <div class="ab-GridTable-cell" role="cell">あり</div>
+        <div class="ab-GridTable-cell" role="cell">１ヶ月後の月末</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要

* Grid と Table を合わせた単語なので、Gridtable を GridTable にリネームする

## スクリーンショット


## ユーザ影響

* 以下のようなクラス名変更があります
```
.ab-Gridtable => .ab-GridTable
.ab-Gridtable-bordered => .ab-GridTable-bordered
.ab-Gridtable-rowgroup => .ab-GridTable-rowgroup
.ab-Gridtable-select => .ab-GridTable-select
```