### PR TITLE
[CSS] LinkText の focus 時に underline を表示しないようにする

### DIFF
--- a/.changeset/fair-camels-greet.md
+++ b/.changeset/fair-camels-greet.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[change:LinkText] Focus 時は underline なしにした

--- a/packages/css/src/components/linktext/index.scss
+++ b/packages/css/src/components/linktext/index.scss
@@ -2,7 +2,7 @@
   --linktext-color: var(--ab-semantic-color-text-default);
   --linktext-text-decoration: underline;
   --linktext-focus-color: var(--ab-semantic-color-text-default);
-  --linktext-focus-text-decoration: underline;
+  --linktext-focus-text-decoration: none;
   --linktext-hover-color: var(--ab-semantic-color-text-default);
   --linktext-hover-text-decoration: none;
   --linktext-active-color: var(--ab-semantic-color-text-default);


### PR DESCRIPTION
## 概要

* focus 時に underline を表示しないようにする
* というのも、focus 時に OS が枠を作ってしまうので、underline あると分かりにくくなる

## スクリーンショット

<img width="419" alt="スクリーンショット 2024-10-03 20 12 01" src="https://github.com/user-attachments/assets/832e276e-2dfe-4e5d-8461-fe33dec1e18d">


## ユーザ影響

* focus 時に underline が消えます