### PR TITLE
[CSS] LinkText は underline なしを指定可能とした

### DIFF
--- a/.changeset/gentle-penguins-buy.md
+++ b/.changeset/gentle-penguins-buy.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[add:LinkText] optional で underline なしの LinkText を追加

--- a/packages/css/src/components/linktext/index.scss
+++ b/packages/css/src/components/linktext/index.scss
@@ -24,6 +24,10 @@
   --linktext-disabled-text-decoration: none;
 }
 
+.ab-LinkText-quiet {
+  --linktext-text-decoration: none;
+}
+
 .ab-LinkText {
   color: var(--linktext-color);
   text-decoration: var(--linktext-text-decoration);

--- a/packages/css/src/components/linktext/stories/Underline.stories.ts
+++ b/packages/css/src/components/linktext/stories/Underline.stories.ts
@@ -1,0 +1,36 @@
+import { meta, createComponent } from './shared';
+import type { Story } from './shared';
+import { plus } from '../../../../story_assets/inlines';
+
+export default {
+  ...meta,
+  title: 'Component/LinkText/Underline',
+};
+
+export const Underline: Story = {
+  render: (args) => {
+    return `
+<div>
+  <div class="ab-flex ab-flex-row ab-gap-8">
+    ${createComponent({ ...args, children: 'Default Underlined', quiet: false, type: 'default' })}
+    ${createComponent({ ...args, children: 'No Underline', quiet: true, type: 'default' })}
+    ${createComponent({ ...args, children: `${plus('ab-Icon ab-Icon-small')}IconUnderlined`, type: 'default' })}
+    ${createComponent({ ...args, children: `${plus('ab-Icon ab-Icon-small')}IconNoUnderlined`, quiet: true, type: 'default' })}
+  </div>
+  <div class="ab-flex ab-flex-row ab-gap-8">
+    ${createComponent({ ...args, children: 'Brand Underlined', quiet: false, type: 'brand' })}
+    ${createComponent({ ...args, children: 'Brand No Underline', quiet: true, type: 'brand' })}
+    ${createComponent({ ...args, children: `${plus('ab-Icon ab-Icon-small')}IconBrandUnderlined`, type: 'brand' })}
+    ${createComponent({ ...args, children: `${plus('ab-Icon ab-Icon-small')}IconBrandNoUnderlined`, quiet: true, type: 'brand' })}
+  </div>
+</div>
+  `;
+  },
+  parameters: {
+    pseudo: {
+      hover: '#hover',
+      active: '#active',
+      focus: '#focus',
+    },
+  },
+};

--- a/packages/css/src/components/linktext/stories/shared.ts
+++ b/packages/css/src/components/linktext/stories/shared.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 
 export type Args = {
   type: 'default' | 'brand';
+  quiet: boolean;
 };
 
 export const meta: Meta<Args> = {
@@ -9,6 +10,9 @@ export const meta: Meta<Args> = {
     type: {
       control: { type: 'select' },
       options: ['default', 'brand'],
+    },
+    quiet: {
+      type: 'boolean',
     },
   },
   parameters: {},
@@ -24,11 +28,13 @@ type ComponentArgs = Args & {
 export const createComponent = ({
   children,
   type = 'default',
+  quiet = false,
   id = 'default',
 }: ComponentArgs): string => {
   const typeClass = type === 'default' ? '' : `ab-LinkText-${type}`;
+  const quietClass = quiet && 'ab-LinkText-quiet';
 
   return `<a id="${id}" class="ab-LinkText ${
     id === 'disabled' ? 'is-disabled' : ''
-  } ${typeClass}">${children}</a>`;
+  } ${typeClass} ${quietClass}">${children}</a>`;
 };


### PR DESCRIPTION
## 概要

* LinkText は underline なしを指定可能とした

## スクリーンショット

![スクリーンショット 2024-10-04 10 17 58](https://github.com/user-attachments/assets/2b9d788d-04ec-4d47-b026-cfda3efd0237)


## ユーザ影響

* なし
    * underline なしは追加
