### PR TITLE
[React] LinkText は underline なしを指定可能とした

### DIFF
--- a/.changeset/seven-pillows-doubt.md
+++ b/.changeset/seven-pillows-doubt.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-react": patch
+---
+
+[add:LinkText] optional で underline なしを指定可能とした

--- a/packages/react/src/components/linkText/Index.tsx
+++ b/packages/react/src/components/linkText/Index.tsx
@@ -5,17 +5,26 @@ import type { ComponentPropsWithoutRef, ElementRef } from 'react';
 export type LinkTextProps = ComponentPropsWithoutRef<'a'> & {
   variant?: 'default' | 'brand';
   disabled?: boolean;
+  underline?: boolean;
 };
 
 export const LinkText = forwardRef<ElementRef<'a'>, LinkTextProps>(
   (
-    { variant = 'default', disabled, children, className, ...rest },
+    {
+      variant = 'default',
+      disabled,
+      underline = true,
+      children,
+      className,
+      ...rest
+    },
     forwardedRef,
   ) => {
     const classes = classNames(
       'ab-LinkText',
       variant !== 'default' && `ab-LinkText-${variant}`,
       disabled && 'is-disabled',
+      !underline && 'ab-LinkText-quiet',
       className,
     );
 

--- a/packages/react/src/components/linkText/LinkText.stories.tsx
+++ b/packages/react/src/components/linkText/LinkText.stories.tsx
@@ -61,3 +61,18 @@ export const Disabled: Story = {
     </>
   ),
 };
+
+export const Underline: Story = {
+  render: ({ ...args }: LinkTextProps) => (
+    <>
+      <div className="ab-flex ab-flex-row ab-gap-8">
+        <LinkText {...args} underline={true}>
+          Default Underline
+        </LinkText>
+        <LinkText {...args} underline={false}>
+          No Underline
+        </LinkText>
+      </div>
+    </>
+  ),
+};


### PR DESCRIPTION
## 概要

* LinkText は underline なしを指定可能とした

## スクリーンショット

![スクリーンショット 2024-10-04 10 17 58](https://github.com/user-attachments/assets/26b0c1ca-2384-4c1e-b68b-46821dcf7127)

## ユーザ影響

* なし
