### PR TITLE
[design token] light theme の場合に ab-bg-rest-secondary と border color を薄くした

### DIFF
--- a/.changeset/silent-peaches-chew.md
+++ b/.changeset/silent-peaches-chew.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-design-tokens": patch
+---
+
+[change:light-bg-color] bg-rest-secondary と border color が薄くなった

--- a/packages/designTokens/tokens/globals/index.tokens.json
+++ b/packages/designTokens/tokens/globals/index.tokens.json
@@ -72,6 +72,10 @@
           "$type": "color",
           "$value": "#f6f7f8"
         },
+        "70": {
+          "$type": "color",
+          "$value": "#eaeef0"
+        },
         "100": {
           "$type": "color",
           "$value": "#e1e7ea"
@@ -161,6 +165,10 @@
         "50": {
           "$type": "color",
           "$value": "#f2f2f2"
+        },
+        "70": {
+          "$type": "color",
+          "$value": "#e5e5e5"
         },
         "100": {
           "$type": "color",

--- a/packages/designTokens/tokens/semantics/brands/g4b-light/index.tokens.json
+++ b/packages/designTokens/tokens/semantics/brands/g4b-light/index.tokens.json
@@ -46,7 +46,7 @@
         },
         "rest-secondary": {
           "$type": "color",
-          "$value": "{global.color.steel.100}"
+          "$value": "{global.color.steel.70}"
         },
         "rest-accent": {
           "$type": "color",
@@ -144,7 +144,7 @@
         },
         "light": {
           "$type": "color",
-          "$value": "{global.color.steel.200}"
+          "$value": "{global.color.steel.100}"
         },
         "info": {
           "$type": "color",

--- a/packages/designTokens/tokens/semantics/brands/skeleton-light/index.tokens.json
+++ b/packages/designTokens/tokens/semantics/brands/skeleton-light/index.tokens.json
@@ -46,7 +46,7 @@
         },
         "rest-secondary": {
           "$type": "color",
-          "$value": "{global.color.steel.100}"
+          "$value": "{global.color.steel.70}"
         },
         "rest-accent": {
           "$type": "color",
@@ -144,7 +144,7 @@
         },
         "light": {
           "$type": "color",
-          "$value": "{global.color.slate.200}"
+          "$value": "{global.color.slate.100}"
         },
         "info": {
           "$type": "color",


### PR DESCRIPTION
## 概要

* light theme の場合に、ab-bg-rest-secondary と border color の見分けがつかない。また、ab-bg-rest-secondary が若干濃い
* そのため、ab-bg-rest-secondary を薄くしつつ、それに合わせるように border color も薄くした

## スクリーンショット

* bg rest-secondary before
    * ![スクリーンショット 2024-11-05 10 39 07](https://github.com/user-attachments/assets/316be0f0-75cd-4d09-97c7-df2e591e19e2)
* after
    * ![スクリーンショット 2024-11-05 10 39 01](https://github.com/user-attachments/assets/27bacfeb-5d76-4ede-aaec-41444c0bebfc)

* border before
    * ![スクリーンショット 2024-11-05 10 40 07](https://github.com/user-attachments/assets/b4cc0518-f501-4747-bdd5-0f1e16a9dac7)
* after
    * ![スクリーンショット 2024-11-05 10 40 10](https://github.com/user-attachments/assets/36bc0c88-540e-40ec-9338-78a43a0dd5f3)

## ユーザ影響

* light theme の場合に ab-bg-rest-secondary と border color が薄くなります
