### PR TITLE
[React] GridTable の GridTableBodyCell に colSpan を設定可能とした

### DIFF
--- a/.changeset/tasty-camels-occur.md
+++ b/.changeset/tasty-camels-occur.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-react": minor
+---
+
+[add:GridTable] Cell に colSpan を設定可能とした

--- a/packages/react/src/components/gridTable/GridTable.stories.tsx
+++ b/packages/react/src/components/gridTable/GridTable.stories.tsx
@@ -351,6 +351,88 @@ export const RowSpan: Story = {
   ),
 };
 
+export const ColSpan: Story = {
+  render: ({ ...args }: GridTable.RootProps) => (
+    <>
+      <Typography>GridTable.BodyCell に colSpan を設定できます。</Typography>
+      <GridTable.Root {...args}>
+        <GridTable.Header>
+          <GridTable.Row>
+            <GridTable.HeaderCell>商品情報</GridTable.HeaderCell>
+            <GridTable.HeaderCell align="right">価格</GridTable.HeaderCell>
+            <GridTable.HeaderCell align="right">数量</GridTable.HeaderCell>
+            <GridTable.HeaderCell align="right">小計</GridTable.HeaderCell>
+          </GridTable.Row>
+        </GridTable.Header>
+        <GridTable.Body>
+          <GridTable.RowGroup>
+            <GridTable.Row>
+              <GridTable.BodyCell rowSpan={4}>
+                <Typography variant="body-xs" className="ab-text-secondary">
+                  ギフティ
+                </Typography>
+                <Typography variant="body-s" className="ab-block">
+                  giftee Box
+                </Typography>
+              </GridTable.BodyCell>
+              <GridTable.BodyCell align="right">¥100</GridTable.BodyCell>
+              <GridTable.BodyCell align="right">¥10</GridTable.BodyCell>
+              <GridTable.BodyCell align="right">¥1,000</GridTable.BodyCell>
+            </GridTable.Row>
+            <GridTable.Row>
+              <GridTable.BodyCell colSpan={3} align="right">
+                長めのエラーメッセージがここに来たりするかも知れない
+              </GridTable.BodyCell>
+            </GridTable.Row>
+            <GridTable.Row>
+              <GridTable.BodyCell align="right">¥200</GridTable.BodyCell>
+              <GridTable.BodyCell align="right">¥30</GridTable.BodyCell>
+              <GridTable.BodyCell align="right">¥6,000</GridTable.BodyCell>
+            </GridTable.Row>
+            <GridTable.Row>
+              <GridTable.BodyCell colSpan={3} align="right">
+                長めのエラーメッセージがここに来たりするかも知れない
+              </GridTable.BodyCell>
+            </GridTable.Row>
+          </GridTable.RowGroup>
+          <GridTable.RowGroup>
+            <GridTable.Row>
+              <GridTable.BodyCell rowSpan={3}>
+                <div className="ab-flex ab-items-center">
+                  <img
+                    src="https://abukuma-css-storybook.netlify.app/assets/giftee-box-Bjg1pmYW.svg"
+                    className="ab-mr-2 ab-inline"
+                    style={{ height: '56px' }}
+                  />
+                  <div className="ab-flex ab-flex-column">
+                    <Typography variant="body-xs" className="ab-text-secondary">
+                      ギフティ
+                    </Typography>
+                    <Typography variant="body-s">giftee Box</Typography>
+                  </div>
+                </div>
+              </GridTable.BodyCell>
+              <GridTable.BodyCell align="right">¥100</GridTable.BodyCell>
+              <GridTable.BodyCell align="right">¥10</GridTable.BodyCell>
+              <GridTable.BodyCell align="right">¥1,000</GridTable.BodyCell>
+            </GridTable.Row>
+            <GridTable.Row>
+              <GridTable.BodyCell align="right">¥200</GridTable.BodyCell>
+              <GridTable.BodyCell align="right">¥30</GridTable.BodyCell>
+              <GridTable.BodyCell align="right">¥6,000</GridTable.BodyCell>
+            </GridTable.Row>
+            <GridTable.Row>
+              <GridTable.BodyCell align="right">¥300</GridTable.BodyCell>
+              <GridTable.BodyCell align="right">¥50</GridTable.BodyCell>
+              <GridTable.BodyCell align="right">¥10,000</GridTable.BodyCell>
+            </GridTable.Row>
+          </GridTable.RowGroup>
+        </GridTable.Body>
+      </GridTable.Root>
+    </>
+  ),
+};
+
 export const GridColumn: Story = {
   render: ({ ...args }: GridTable.RootProps) => (
     <>

--- a/packages/react/src/components/gridTable/GridTableBodyCell.tsx
+++ b/packages/react/src/components/gridTable/GridTableBodyCell.tsx
@@ -5,6 +5,7 @@ import type { ComponentPropsWithoutRef, ElementRef } from 'react';
 export type GridTableBodyCellProps = ComponentPropsWithoutRef<'div'> & {
   align?: 'center' | 'left' | 'right';
   rowSpan?: number;
+  colSpan?: number;
   isBordered?: boolean;
 };
 
@@ -13,7 +14,16 @@ export const GridTableBodyCell = forwardRef<
   GridTableBodyCellProps
 >(
   (
-    { align, rowSpan, isBordered = false, children, className, style, ...rest },
+    {
+      align,
+      rowSpan,
+      colSpan,
+      isBordered = false,
+      children,
+      className,
+      style,
+      ...rest
+    },
     forwardedRef,
   ) => {
     const classes = classNames(
@@ -25,13 +35,16 @@ export const GridTableBodyCell = forwardRef<
     const rowSpanStyle = rowSpan
       ? { '--ab-gridtable-cell-rowspan': rowSpan }
       : {};
+    const colSpanStyle = colSpan
+      ? { '--ab-gridtable-cell-colspan': colSpan }
+      : {};
 
     return (
       <div
         ref={forwardedRef}
         className={classes}
         role="cell"
-        style={{ ...rowSpanStyle, ...style }}
+        style={{ ...rowSpanStyle, ...colSpanStyle, ...style }}
         {...rest}
       >
         {children}


### PR DESCRIPTION
## 概要

* GridTable の GridTableBodyCell に colSpan を設定可能とした

## スクリーンショット

![スクリーンショット 2024-11-06 10 50 27](https://github.com/user-attachments/assets/e4853558-9ba3-4313-8930-7f6c483ec4aa)

## ユーザ影響

* 追加なのでなし
