### PR TITLE
[CSS] Accordion に border-radius を追加

### DIFF
--- a/.changeset/lovely-singers-confess.md
+++ b/.changeset/lovely-singers-confess.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[enhancement:Accordion] boreder-radius を設定し丸い印象に変更

--- a/packages/css/src/components/accordion/index.scss
+++ b/packages/css/src/components/accordion/index.scss
@@ -48,6 +48,7 @@ $minus-url: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvM
   font-size: var(--accordion-font-size);
   color: var(--accordion-color);
   list-style: none;
+  border-radius: var(--ab-semantic-border-radius-lg);
 
   &-summary {
     overflow: hidden;
@@ -145,6 +146,7 @@ $minus-url: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvM
 .ab-Accordion-summary {
   .is-disabled & {
     background-color: var(--accordion-disabled-summary-background-color);
+    border-radius: var(--ab-semantic-border-radius-lg);
 
     &::before {
       color: var(--accordion-disabled-summary-icon-color);


### PR DESCRIPTION
## 概要

* Accordion に border-radius がついておらず意図してないデザインになっていたので、デザイン側に追従

## スクリーンショット


<img width="558" alt="スクリーンショット 2024-11-07 17 01 14" src="https://github.com/user-attachments/assets/121bead1-3b7b-447c-a5a2-38d666f5192f">

## ユーザ影響

* 見た目で角丸がつきます
