### PR TITLE
[CSS] ネストした MenuItem の左 padding が小さいので修正する

### DIFF
--- a/.changeset/large-swans-punch.md
+++ b/.changeset/large-swans-punch.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[enhance:Menu]ネストした MenuItem の左 padding が狭い問題を修正

--- a/packages/css/src/components/menu/index.scss
+++ b/packages/css/src/components/menu/index.scss
@@ -72,7 +72,7 @@
       border-radius: var(--ab-semantic-border-radius-lg);
 
       .ab-Menu-sub-menu & {
-        padding: var(--ab-semantic-spacing-2);
+        padding-right: var(--ab-semantic-spacing-2);
       }
 
       svg {

--- a/packages/css/src/components/menu/stories/Collapsible.stories.ts
+++ b/packages/css/src/components/menu/stories/Collapsible.stories.ts
@@ -37,10 +37,16 @@ export const Collapsible: Story = {
     </button>
     <ul class="ab-Menu-sub-menu" role="menu">
       <li class="ab-Menu-item" role="menuitem">
-        <a ref="#" class="ab-Menu-item-link"> サブメニュ− 1</a>
+        <a ref="#" class="ab-Menu-item-link">
+          サブメニュ− 1
+          ${angleRight('ab-Icon ab-ml-auto')}
+        </a>
       </li>
       <li class="ab-Menu-item" role="menuitem">
-        <a ref="#" class="ab-Menu-item-link"> サブメニュ− 2</a>
+        <a ref="#" class="ab-Menu-item-link">
+          サブメニュ− 2
+          ${angleRight('ab-Icon ab-ml-auto')}
+        </a>
       </li>
     </ul>
   </li>
@@ -52,10 +58,16 @@ export const Collapsible: Story = {
     </button>
     <ul class="ab-Menu-sub-menu" role="menu">
       <li class="ab-Menu-item" role="menuitem">
-        <a ref="#" class="ab-Menu-item-link"> サブメニュ− 3</a>
+        <a ref="#" class="ab-Menu-item-link">
+          サブメニュ− 3
+          ${angleRight('ab-Icon ab-ml-auto')}
+        </a>
       </li>
       <li class="ab-Menu-item" role="menuitem">
-        <a ref="#" class="ab-Menu-item-link"> サブメニュ− 4</a>
+        <a ref="#" class="ab-Menu-item-link">
+          サブメニュ− 4
+          ${angleRight('ab-Icon ab-ml-auto')}
+        </a>
       </li>
     </ul>
   </li>


### PR DESCRIPTION
## 概要

* ネストした MenuItem の左 padding が小さいので修正する

<img width="286" alt="スクリーンショット 2024-11-07 18 09 27" src="https://github.com/user-attachments/assets/82518cde-6382-4bfa-825e-1bde8d2a450d">


## スクリーンショット

* 左 padding のみ広げつつ、右のアイコンが親メニューと同じ位置になるようにしている

<img width="273" alt="スクリーンショット 2024-11-07 18 11 33" src="https://github.com/user-attachments/assets/0dfad70a-47bb-4c88-a039-31fff29da402">

## ユーザ影響

* 左 padding が 4px 広くなります
