### PR TITLE
[InlineAlert] title,description のみの Story を追加

### DIFF
--- a/packages/css/src/components/inlinealert/stories/Customize.stories.ts
+++ b/packages/css/src/components/inlinealert/stories/Customize.stories.ts
@@ -1,0 +1,41 @@
+import { meta } from './shared';
+import type { Story } from './shared';
+import { circleInfo } from '../../../../story_assets/inlines';
+
+export default {
+  ...meta,
+  title: 'Component/InlineAlert/Customize',
+};
+
+export const Customize: Story = {
+  render: (_args) => {
+    return `
+    <div class="ab-InlineAlert ab-InlineAlert-info ab-mb-4">
+      <div class="ab-InlineAlert-title">
+        ${circleInfo('ab-Icon ab-Icon-medium')}
+        title のみ
+      </div>
+    </div>
+    <div class="ab-InlineAlert ab-InlineAlert-info ab-mb-4">
+      <div class="ab-InlineAlert-description">description のみ</div>
+    </div>
+    <div class="ab-InlineAlert ab-InlineAlert-info ab-mb-4">
+      <div class="ab-InlineAlert-title">
+        ${circleInfo('ab-Icon ab-Icon-medium ab-text-notice')}
+        title, description 両方あり
+      </div>
+      <div class="ab-InlineAlert-description">テキストが入りますテキストが入りますテキストが入りますテキストが入りますテキストが入りますテキストが入りますテキストが入りますテキストが入ります</div>
+    </div>
+  `;
+  },
+  args: {
+    type: 'neutral',
+  },
+  parameters: {
+    pseudo: {
+      hover: '#hover',
+      active: '#active',
+      focus: '#focus',
+    },
+  },
+};

--- a/packages/react/src/components/inlineAlert/InlineAlert.stories.tsx
+++ b/packages/react/src/components/inlineAlert/InlineAlert.stories.tsx
@@ -82,3 +82,28 @@ export const Variant: Story = {
     </div>
   ),
 };
+
+export const Customize: Story = {
+  render: ({ children, ...args }: InlineAlert.RootProps) => (
+    <div className="ab-flex ab-flex-column ab-gap-8">
+      <InlineAlert.Root {...args} variant="info">
+        <InlineAlert.Title>
+          <CircleInfo className="ab-Icon ab-Icon-medium ab-text-neutral" />
+          titleのみ
+        </InlineAlert.Title>
+      </InlineAlert.Root>
+      <InlineAlert.Root {...args} variant="info">
+        <InlineAlert.Description>description のみ</InlineAlert.Description>
+      </InlineAlert.Root>
+      <InlineAlert.Root {...args} variant="info">
+        <InlineAlert.Title>
+          <CircleExclamation className="ab-Icon ab-Icon-medium ab-text-notice" />
+          title, description 両方あり
+        </InlineAlert.Title>
+        <InlineAlert.Description>
+          テキストが入りますテキストが入りますテキストが入りますテキストが入りますテキストが入りますテキストが入りますテキストが入りますテキストが入ります
+        </InlineAlert.Description>
+      </InlineAlert.Root>
+    </div>
+  ),
+};


### PR DESCRIPTION
## 概要

* InlineAlert は title のみ、description のみで利用しても良いため、それをドキュメントに追加したい
* よって、Story を追加する

## スクリーンショット


## ユーザ影響

* なし
