### PR TITLE
[CSS] 端のcellにrowspanが設定されている時、隣のcellのpaddingが2行目以降でずれてしまう問題を修正

### DIFF
--- a/.changeset/fluffy-ghosts-divide.md
+++ b/.changeset/fluffy-ghosts-divide.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[fix:GridTable] 端のcellにrowspanが設定されている時、隣のcellのpaddingが2行目以降でずれてしまう問題を修正

--- a/packages/css/src/components/gridtable/index.scss
+++ b/packages/css/src/components/gridtable/index.scss
@@ -9,7 +9,7 @@
 
     &-cell {
       height: 50px;
-      padding: var(--ab-semantic-spacing-4);
+      padding: var(--ab-semantic-spacing-4) var(--ab-semantic-spacing-2);
       text-align: left;
       font-weight: var(--ab-semantic-typography-font-weight-bold);
       place-content: end;
@@ -18,10 +18,11 @@
 
   &-row {
     .ab-GridTable-head-cell:first-child {
-      padding-left: var(--ab-semantic-spacing-8);
+      padding-left: var(--ab-semantic-spacing-6);
     }
+
     .ab-GridTable-head-cell:last-child {
-      padding-right: var(--ab-semantic-spacing-8);
+      padding-right: var(--ab-semantic-spacing-6);
     }
   }
 
@@ -54,7 +55,7 @@
   }
 
   &-cell {
-    padding: var(--ab-semantic-spacing-4);
+    padding: var(--ab-semantic-spacing-4) var(--ab-semantic-spacing-2);
     text-align: left;
     overflow: hidden;
     place-content: center;


### PR DESCRIPTION
## 概要

- 既存実装は端のcellのpaddingをheaderとbodyで合わせるための調整を`.ab-GridTable-cell:first-child / .ab-GridTable-cell:last-child`で行っていた( https://github.com/giftee/design-system/commit/00087dccd83d62da233be714aaeb4d9e3e3c9275)
- しかし端のcellにrowspanが設定されている時、隣のcellに意図せず上記のstyleがあたってしまい、paddingがずれる問題が発生していた
  <img width="1434" alt="image" src="https://github.com/user-attachments/assets/be46c03e-be86-4721-8b8f-26aacd20ddd5">
  - 上掲のスクショの場合、「価格」列で2行目のpaddingがずれてしまっている
- これを解消するために`.ab-GridTable-cell:first-child / .ab-GridTable-cell:last-child`での調整をやめ、headerのpaddingをbodyの端のpaddingと同じ値にする

## スクリーンショット
<img width="955" alt="image" src="https://github.com/user-attachments/assets/d46f8e10-4bbd-4de4-8cfd-3fcfe8813506">

### 左端のpadding
- 左端にrowspanが設定されている時、隣の列の左のpaddingが揃っている
- 左端のheaderとbodyのalignを左揃えにした時、headerとbodyのpaddingが揃っている
<img width="490" alt="image" src="https://github.com/user-attachments/assets/9c6888a3-d0d7-4611-88b0-334fb6b395a6">


### 右端のpadding
- 右端にrowspanが設定されている時、隣の列の右のpaddingが揃っている
- 右端のheaderとbodyのalignを右揃えにした時、headerとbodyのpaddingが揃っている
<img width="490" alt="image" src="https://github.com/user-attachments/assets/7d1a46a7-d27f-4620-84e9-519815dfab45">

## ユーザ影響
- bodyのcell自体のx軸paddingを(端であるかに関わらず)`var(--ab-semantic-spacing-2)`で統一しています
- これが意図しない変更の場合はご指摘お願いします

### 変更前
<img width="314" alt="image" src="https://github.com/user-attachments/assets/d82b556a-00ab-4cf8-abc6-1e1137f8d825">

### 変更後
<img width="320" alt="image" src="https://github.com/user-attachments/assets/4f86228a-a6da-467b-acaa-16d5a3aa7d99">
