### PR TITLE
[React] IconButton に negative を追加

### DIFF
--- a/.changeset/five-clouds-exercise.md
+++ b/.changeset/five-clouds-exercise.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-react": minor
+---
+
+[add:IconButton] negative color を追加

--- a/packages/react/src/components/iconButton/IconButton.stories.tsx
+++ b/packages/react/src/components/iconButton/IconButton.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
   argTypes: {
     variant: {
       control: { type: 'select' },
-      options: ['default', 'outlined', 'neutral', 'text'],
+      options: ['default', 'outlined', 'neutral', 'text', 'negative'],
       table: {
         defaultValue: {
           summary: 'default',
@@ -52,6 +52,9 @@ export const Variant: Story = {
         {children}
       </IconButton>
       <IconButton {...args} variant="text">
+        {children}
+      </IconButton>
+      <IconButton {...args} variant="negative">
         {children}
       </IconButton>
     </>

--- a/packages/react/src/components/iconButton/Index.tsx
+++ b/packages/react/src/components/iconButton/Index.tsx
@@ -3,7 +3,7 @@ import { classNames } from '@/utils/classNames';
 import type { ComponentPropsWithoutRef, ElementRef } from 'react';
 
 export type IconButtonProps = ComponentPropsWithoutRef<'button'> & {
-  variant?: 'default' | 'outlined' | 'neutral' | 'text';
+  variant?: 'default' | 'outlined' | 'neutral' | 'text' | 'negative';
   size?: 'small' | 'large';
 };
 


### PR DESCRIPTION
## 概要

* IconButton に negative を追加
    * https://github.com/giftee/design-system/pull/227 の react 版です

## スクリーンショット

* CSS の PR を参照してください

## ユーザ影響

* 追加なのでなし
