### PR TITLE
[CSS：InlineAlert] 親要素が中央、右寄せでも左寄せにする

### DIFF
--- a/.changeset/clever-rabbits-stick.md
+++ b/.changeset/clever-rabbits-stick.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[fix:InlineAlert] 親要素が centering すると inline-alert も centering される問題を修正

--- a/packages/css/src/components/inlinealert/index.scss
+++ b/packages/css/src/components/inlinealert/index.scss
@@ -49,6 +49,7 @@
   gap: var(--ab-semantic-spacing-2);
   padding: var(--ab-semantic-spacing-6);
   border-radius: var(--ab-semantic-border-radius-md);
+  text-align: left;
 
   &-neutral,
   &-info,


### PR DESCRIPTION
## 概要

* InlineAlert の親要素が text-align: center, right などで右寄せしてると、InlineAlert 内部も追従する
* よって、InlineAlert は左寄せにする

## スクリーンショット

* 見た目上の変更はなし

<img width="695" alt="スクリーンショット 2025-03-10 18 54 49" src="https://github.com/user-attachments/assets/e5c0023d-7abf-425d-bdfc-2967244ce681" />

## ユーザ影響

* なし
