### PR TITLE
[DesignToken] package.json の type を module に変更

### DIFF
--- a/.changeset/kind-tigers-switch.md
+++ b/.changeset/kind-tigers-switch.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-design-tokens": patch
+---
+
+[enhancement] type: module にして、デフォルトを esm で扱えるようにする

--- a/packages/designTokens/build.js
+++ b/packages/designTokens/build.js
@@ -1,4 +1,4 @@
-const StyleDictionaryPackage = require('style-dictionary');
+import StyleDictionaryPackage from 'style-dictionary';
 
 const PATH = 'tokens';
 const getStyleDictionaryConfig = (brand) => {

--- a/packages/designTokens/package.json
+++ b/packages/designTokens/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "description": "Design Tokens of Giftee Design System",
+  "type": "module",
   "style": "dist/css/index.css",
   "main": "dist/cjs/index.js",
   "typings": "dist/types/index.d.ts",


### PR DESCRIPTION
## 概要

* package.json の type を module に変更して、`.js` ファイルは esm として扱うようにする
* common js も吐き出しているので、使いたい人は明示的にそちらを使ってもらう
    * → 基本的にブラウザ利用想定なので問題ないはず

## スクリーンショット

* なし

## ユーザ影響

* なし
