### PR TITLE
[React] slotProps を導入し input/textarea タグに props を渡せるようにする

### DIFF
--- a/.changeset/social-ducks-sip.md
+++ b/.changeset/social-ducks-sip.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-react": minor
+---
+
+[add:Textfield] slotProps を導入し input/textarea に props を渡せるようにする

--- a/packages/react/src/components/textfield/Index.tsx
+++ b/packages/react/src/components/textfield/Index.tsx
@@ -10,6 +10,10 @@ export type TextfieldProps = ComponentPropsWithoutRef<'input'> &
     error?: boolean;
     multiline?: number;
     resize?: 'vertical' | 'horizontal' | 'both' | 'none';
+    slotProps?: {
+      input?: ComponentPropsWithoutRef<'input'>;
+      textarea?: ComponentPropsWithoutRef<'textarea'>;
+    };
   };
 
 export const Textfield = forwardRef<
@@ -28,6 +32,7 @@ export const Textfield = forwardRef<
       resize = 'none',
       children,
       className,
+      slotProps,
       ...rest
     },
     forwardedRef,
@@ -58,20 +63,28 @@ export const Textfield = forwardRef<
           <input
             id={name}
             name={name}
-            className="ab-Textfield-input"
             ref={forwardedRef}
             required={required}
             {...rest}
+            {...slotProps?.input}
+            className={classNames(
+              'ab-Textfield-input',
+              slotProps?.input?.className,
+            )}
           />
         ) : (
           <textarea
             id={name}
             name={name}
-            className="ab-Textfield-textarea"
             ref={forwardedRef}
             required={required}
             rows={multiline}
             {...rest}
+            {...slotProps?.textarea}
+            className={classNames(
+              'ab-Textfield-textarea',
+              slotProps?.textarea?.className,
+            )}
           />
         )}
         {!!helptext && <div className="ab-Textfield-helptext">{helptext}</div>}

--- a/packages/react/src/components/textfield/Textfield.stories.tsx
+++ b/packages/react/src/components/textfield/Textfield.stories.tsx
@@ -14,6 +14,7 @@ const meta = {
     disabled: false,
     multiline: undefined,
     resize: 'none',
+    slotProps: undefined,
   },
   argTypes: {
     label: {
@@ -69,6 +70,15 @@ const meta = {
         },
       },
       description: 'テキストエリアデフォルト行数',
+    },
+    slotProps: {
+      control: { type: 'object' },
+      table: {
+        defaultValue: {
+          summary: undefined,
+        },
+      },
+      description: 'SlotProps',
     },
   },
 } satisfies Meta<typeof Textfield>;
@@ -169,6 +179,36 @@ export const Disabled: Story = {
           helptext="disabled"
         ></Textfield>
         <Textfield name="notDisabled" {...args}></Textfield>
+      </div>
+    </>
+  ),
+};
+
+export const SlotProps: Story = {
+  render: ({ ...args }: TextfieldProps) => (
+    <>
+      <div className="ab-flex ab-flex-column ab-gap-12">
+        <Textfield
+          name="slotProps"
+          {...args}
+          helptext="slotProps で input tag に ab-w-120 を設定しています"
+          slotProps={{
+            input: {
+              className: 'ab-w-120',
+            },
+          }}
+        />
+        <Textfield
+          name="slotProps"
+          {...args}
+          multiline={5}
+          helptext="slotProps で textarea tag に ab-w-120 を設定しています"
+          slotProps={{
+            textarea: {
+              className: 'ab-w-120',
+            },
+          }}
+        />
       </div>
     </>
   ),


### PR DESCRIPTION
## 概要

* slotProps を導入し input/textarea タグに props を渡せるようにする

## スクリーンショット

![スクリーンショット 2025-03-25 12 38 16](https://github.com/user-attachments/assets/6e7f4060-4e97-4858-a8ed-6e2fbf7df80d)


## ユーザ影響

* 既存影響はなし
* input/textarea に追加で props を渡せるようになる
