### PR TITLE
[CSS] Textfield のエラー表示に helptext ではなく error-message クラスを利用する

### DIFF
--- a/.changeset/icy-mugs-accept.md
+++ b/.changeset/icy-mugs-accept.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": minor
+---
+
+[breaking: Textfield] エラー表示には helptext ではなく error-message クラスを使う

--- a/packages/css/src/components/textfield/index.scss
+++ b/packages/css/src/components/textfield/index.scss
@@ -75,6 +75,13 @@
     min-height: var(--textfield-input-height);
   }
 
+  &-error-message {
+    padding-top: var(--ab-semantic-spacing-1);
+    font-size: css-design-tokens.$font-size-body-xs;
+    color: var(--ab-semantic-color-text-negative);
+    font-weight: var(--ab-semantic-typography-font-weight-bold);
+  }
+
   &-helptext {
     padding-top: var(--ab-semantic-spacing-1);
     font-size: css-design-tokens.$font-size-body-xs;
@@ -118,9 +125,5 @@
 .ab-Textfield-helptext {
   .is-disabled & {
     color: var(--ab-semantic-color-text-secondary);
-  }
-
-  .is-error & {
-    color: var(--ab-semantic-color-text-negative);
   }
 }

--- a/packages/css/src/components/textfield/stories/State.stories.ts
+++ b/packages/css/src/components/textfield/stories/State.stories.ts
@@ -87,7 +87,9 @@ export const State: Story = {
       name="field"
       class="ab-Textfield-input"
     />
-    <div class="ab-Textfield-helptext">error</div>
+    <div class="ab-Textfield-error-message">error</div>
+    <div class="ab-Textfield-error-message">error</div>
+    <div class="ab-Textfield-helptext">helptext</div>
   </div>
 </div>
   `;


### PR DESCRIPTION
## 概要

* Textfield のエラー表示に helptext ではなく error-message クラスを利用する

## スクリーンショット

![スクリーンショット 2025-03-28 19 12 28](https://github.com/user-attachments/assets/02ca22ca-13d7-408f-b2c4-2efddd806574)

## ユーザ影響

* 影響あり
    * Textfield でエラーメッセージを表示している箇所では、ab-Textfield-helptext の代わりに ab-Textfield-error-message クラスを利用してください
    * ab-Textfield-helptext は is-error を付加していても赤い表示に変わりません
