### PR TITLE
[React] Textfield のエラー表示に helptext ではなく error-message クラスを利用する

### DIFF
--- a/.changeset/wide-tires-sit.md
+++ b/.changeset/wide-tires-sit.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-react": minor
+---
+
+[breaking:Textfield] エラーメッセージには helptext ではなく errorMessages props を利用するようにする

--- a/packages/react/src/components/textfield/Index.tsx
+++ b/packages/react/src/components/textfield/Index.tsx
@@ -8,6 +8,7 @@ export type TextfieldProps = ComponentPropsWithoutRef<'input'> &
     label?: string;
     helptext?: string;
     error?: boolean;
+    errorMessages?: string[] | string;
     multiline?: number;
     resize?: 'vertical' | 'horizontal' | 'both' | 'none';
     slotProps?: {
@@ -25,6 +26,7 @@ export const Textfield = forwardRef<
       label,
       helptext,
       error,
+      errorMessages,
       name,
       required,
       disabled,
@@ -86,6 +88,15 @@ export const Textfield = forwardRef<
               slotProps?.textarea?.className,
             )}
           />
+        )}
+        {!errorMessages ? null : typeof errorMessages === 'string' ? (
+          <div className="ab-Textfield-error-message">{errorMessages}</div>
+        ) : (
+          errorMessages.map((errorMessage) => (
+            <div key={errorMessage} className="ab-Textfield-error-message">
+              {errorMessage}
+            </div>
+          ))
         )}
         {!!helptext && <div className="ab-Textfield-helptext">{helptext}</div>}
       </div>

--- a/packages/react/src/components/textfield/Textfield.stories.tsx
+++ b/packages/react/src/components/textfield/Textfield.stories.tsx
@@ -10,6 +10,7 @@ const meta = {
     label: 'label',
     helptext: 'helptext',
     error: false,
+    errorMessages: undefined,
     required: false,
     disabled: false,
     multiline: undefined,
@@ -39,10 +40,26 @@ const meta = {
       control: { type: 'boolean' },
       table: {
         defaultValue: {
-          summary: 'false',
+          summary: 'undefined',
         },
       },
-      description: 'エラー',
+      description: 'エラー有無',
+    },
+    errorMessages: {
+      control: { type: 'select' },
+      options: [
+        '単一エラーメッセージ',
+        ['複数エラーメッセージ1', '複数エラーメッセージ2'],
+      ],
+      table: {
+        defaultValue: {
+          summary: 'undefined',
+        },
+        type: {
+          summary: 'string | string[]',
+        },
+      },
+      description: 'エラーメッセージ',
     },
     required: {
       control: { type: 'boolean' },
@@ -157,10 +174,16 @@ export const Error: Story = {
     <>
       <div className="ab-flex ab-flex-column ab-gap-12">
         <Textfield
-          name="error"
+          name="single-error"
           {...args}
           error={true}
-          helptext="エラーメッセージ"
+          errorMessages="単一エラーメッセージ"
+        ></Textfield>
+        <Textfield
+          name="multi-errors"
+          {...args}
+          error={true}
+          errorMessages={['複数エラーメッセージ1', '複数エラーメッセージ2']}
         ></Textfield>
         <Textfield name="notError" {...args}></Textfield>
       </div>


### PR DESCRIPTION
## 概要

* https://github.com/giftee/design-system/pull/406 の React 対応
* errorMessages props を追加し helptext の代わりに利用する

## スクリーンショット

* 

## ユーザ影響

* Textfield を利用してエラー表示をしている場合、helptext から errorMessages の利用に migration をお願いします

```tsx
// before
<Textfield error={true} helptext="エラーメッセージ" />

// after
<Textfield error={true} errorMessages="エラーメッセージ" />
```
