### PR TITLE
[DesignToken] g4b から marine にテーマ名を変更

### DIFF
--- a/.changeset/tough-hands-jump.md
+++ b/.changeset/tough-hands-jump.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-design-tokens": major
+---
+
+[breaking] g4b-light, g4b-dark を marine-light, marine-dark にリネーム

--- a/packages/designTokens/DEVELOP.md
+++ b/packages/designTokens/DEVELOP.md
@@ -31,8 +31,8 @@ $ pnpm build
 Generate した JSON は以下のようになっています。それらを以下のようにコピーしてください。（そのうち自動連携したいです）
 
 - global.base.tokens.json → `tokens/globals/index.tokens.json`
-- semantic-theme.g4b-light.tokens.json → `tokens/semantics/brands/g4b-light/index.tokens.json`
-- semantic-theme.g4b-dark.tokens.json → `tokens/semantics/brands/g4b-dark/index.tokens.json`
+- semantic-theme.marine-light.tokens.json → `tokens/semantics/brands/marine-light/index.tokens.json`
+- semantic-theme.marine-dark.tokens.json → `tokens/semantics/brands/marine-dark/index.tokens.json`
 - semantic-theme.skeleton-light.tokens.json → `tokens/semantics/brands/skeleton-light/index.tokens.json`
 - semantic-common.base.tokens.json → `tokens/semantics/common/index.tokens.json`
 
@@ -49,7 +49,7 @@ Generate した JSON は以下のようになっています。それらを以�
   }
 }
 
-/* semantic-theme.g4b-light.tokens.json */
+/* semantic-theme.marine-light.tokens.json */
 {
   "semantic": {
     "color": {
@@ -62,7 +62,7 @@ Generate した JSON は以下のようになっています。それらを以�
     }
   }
 }
-/* semantic-theme.g4b-dark.tokens.json */
+/* semantic-theme.marine-dark.tokens.json */
 {
   "semantic": {
     "color": {

--- a/packages/designTokens/README.md
+++ b/packages/designTokens/README.md
@@ -10,7 +10,7 @@ $ npm install @giftee/abukuma-design-tokens
 
 ## テーマ
 
-現在、g4b-light, g4b-dark, skeleton-light を提供しています。テーマ設定の方法は言語ごとに違います。
+現在、marine-light, marine-dark, skeleton-light を提供しています。テーマ設定の方法は言語ごとに違います。
 
 ## 使い方
 
@@ -18,7 +18,7 @@ $ npm install @giftee/abukuma-design-tokens
 
 ### CSS/SCSS
 
-CSS variables の形で提供しています。テーマ設定は HTML に `[data-theme=g4b-light]` とすることで可能です。
+CSS variables の形で提供しています。テーマ設定は HTML に `[data-theme=marine-light]` とすることで可能です。
 
 ```css
 @import '@giftee/abukuma-design-tokens';
@@ -29,7 +29,7 @@ CSS variables の形で提供しています。テーマ設定は HTML に `[dat
 JavaScript の object とそれに対応した型定義を提供しています。テーマごとにデザイントークンが import できるので、好きに使ってください。
 
 ```ts
-import { g4bLight, saasLight } from '@giftee/abukuma-design-tokens';
+import { marineLight, saasLight } from '@giftee/abukuma-design-tokens';
 ```
 
 ## 開発

--- a/packages/designTokens/build.js
+++ b/packages/designTokens/build.js
@@ -162,8 +162,8 @@ ${dictionary.allTokens
 
 console.log('Build started...');
 
-const DEFAULT_BRAND = 'g4b-light';
-const NOT_DEFAULT_BRANDS = ['g4b-dark', 'skeleton-light'];
+const DEFAULT_BRAND = 'marine-light';
+const NOT_DEFAULT_BRANDS = ['marine-dark', 'skeleton-light'];
 const BRANDS = [DEFAULT_BRAND, ...NOT_DEFAULT_BRANDS];
 
 BRANDS.map((brand) => {

--- a/packages/designTokens/tokens/semantics/brands/marine-dark/index.tokens.json
+++ b/packages/designTokens/tokens/semantics/brands/marine-dark/index.tokens.json
@@ -43,10 +43,6 @@
           "$type": "color",
           "$value": "{global.color.steel.800}"
         },
-        "warning-primary": {
-          "$type": "color",
-          "$value": "{global.color.green.800}"
-        },
         "negative-primary": {
           "$type": "color",
           "$value": "{global.color.red.800}"

--- a/packages/designTokens/tokens/semantics/brands/marine-light/index.tokens.json
+++ b/packages/designTokens/tokens/semantics/brands/marine-light/index.tokens.json
@@ -43,10 +43,6 @@
           "$type": "color",
           "$value": "{global.color.green.50}"
         },
-        "warning-primary": {
-          "$type": "color",
-          "$value": "{global.color.green.800}"
-        },
         "negative-primary": {
           "$type": "color",
           "$value": "{global.color.red.800}"


### PR DESCRIPTION
## 概要

* g4b から marine にテーマ名を変更する
* これまでは利用コンテキストでテーマ名を考えていて、g4b は giftee for business で利用されることを想定していた
* しかし、marine color は g4b コンテキスト以外でも利用されることが判明した
* また、今後追加予定の coral color も特定のコンテキストに制限できないため、純粋で brand color のテーマ名に変更した

## スクリーンショット

* 特になし

## ユーザ影響

* g4b-light, g4b-dark で以下のように明示的にテーマ指定してる場合は、それを marine-light, marine-dark に変更してください
    * skeleton-light は影響なしです
    * g4b-light をデフォルト利用してる場合は影響なしです

```html
// 変更前
<div data-theme="g4b-dark">
    <button class="ab-Button">g4b-dark Button</button>
    <div data-theme="g4b-light">
        <button class="ab-Button">g4b-light Button</button>
    </div>
</div>

// 変更後
<div data-theme="marine-dark">
    <button class="ab-Button">marine-dark Button</button>
    <div data-theme="marine-light">
        <button class="ab-Button">marine-light Button</button>
    </div>
</div>
```

