### PR TITLE
[CSS] テーマ名を g4b => marine にリネームしつつ、coral-light を追加

### DIFF
--- a/.changeset/dark-needles-give.md
+++ b/.changeset/dark-needles-give.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": major
+---
+
+[breaking] g4b テーマを marine にリネームし、coral-light を追加

--- a/packages/css/.storybook/preview.tsx
+++ b/packages/css/.storybook/preview.tsx
@@ -45,9 +45,10 @@ const preview: Preview = {
                 }
               >
                 <option value="">テーマを選択</option>
-                <option value="g4b-light">g4b-light </option>
-                <option value="g4b-dark">g4b-dark</option>
+                <option value="marine-light">marine-light </option>
+                <option value="marine-dark">marine-dark</option>
                 <option value="skeleton-light">skeleton-light</option>
+                <option value="coral-light">coral-light</option>
               </select>
               <div id="canvas-root">
                 <Canvas sourceState="shown"></Canvas>
@@ -56,15 +57,6 @@ const preview: Preview = {
           </>
         );
       },
-    },
-    backgrounds: {
-      default: 'light',
-      values: [
-        {
-          name: 'light',
-          value: '#f6f7f8',
-        },
-      ],
     },
   },
 };

--- a/packages/css/DEVELOP.md
+++ b/packages/css/DEVELOP.md
@@ -16,7 +16,7 @@ $ pnpm install
     - base： reset.css などのベースとなる CSS が置かれています。
     - components： コンポーネントです。
     - designTokens： デザイントークンが定義されています（`@giftee/abukuma-design-tokens` があるので廃止予定）。
-    - themes： テーマ定義（g4b-light/g4b-dark/skeleton-light）があります。
+    - themes： テーマ定義（marine-light/marine-dark/skeleton-light/coral-light）があります。
     - utilities： spacing などの utility クラスがあります。
 - stories： story 群です。
 - .storybook: storybook の設定です

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -19,23 +19,26 @@ package のインストール後は適切な箇所にインポートして使っ
 ```html
 <body>
   <div>
-    <button class="ab-Button">g4b-light Button</button>
+    <button class="ab-Button">marine-light Button</button>
   </div>
 </body>
 ```
 
 ### テーマ
 
-デフォルトで g4b-light テーマになっています。テーマをスイッチしたい場合は、任意の箇所に `data-theme='g4b-light/skeleton-light'` を追加してください。
+デフォルトで marine-light テーマになっています。テーマをスイッチしたい場合は、任意の箇所に `data-theme='marine-light/marine-dark/skeleton-light/coral-light'` を追加してください。
 
 ```html
 <body>
   <div>
-    <button class="ab-Button">g4b-light Button</button>
-    <div data-theme="g4b-dark">
-      <button class="ab-Button">g4b-dark Button</button>
+    <button class="ab-Button">marine-light Button</button>
+    <div data-theme="marine-dark">
+      <button class="ab-Button">marine-dark Button</button>
       <div data-theme="skeleton-light">
         <button class="ab-Button">skeleton-light Button</button>
+        <div data-theme="coral-light">
+          <button class="ab-Button">coral-light Button</button>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要

* テーマ名を g4b => marine にリネームしつつ、coral-light を追加

## スクリーンショット


## ユーザ影響

* g4b-light, g4b-dark で以下のように明示的にテーマ指定してる場合は、それを marine-light, marine-dark に変更してください
    * skeleton-light は影響なしです
    * g4b-light をデフォルト利用してる場合は影響なしです

```html
// 変更前
<div data-theme="g4b-dark">
    <button class="ab-Button">g4b-dark Button</button>
    <div data-theme="g4b-light">
        <button class="ab-Button">g4b-light Button</button>
    </div>
</div>

// 変更後
<div data-theme="marine-dark">
    <button class="ab-Button">marine-dark Button</button>
    <div data-theme="marine-light">
        <button class="ab-Button">marine-light Button</button>
    </div>
</div>
```

* coral-light は追加なので影響なしです