### PR TITLE
[React] テーマ名を g4b => marine にリネームしつつ、coral-light を追加

### DIFF
--- a/.changeset/sweet-cycles-enjoy.md
+++ b/.changeset/sweet-cycles-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-react": major
+---
+
+[breaking] g4b テーマを marine にリネームし、coral-light を追加

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -59,9 +59,10 @@ const preview: Preview = {
               }
             >
               <option value="">テーマを選択</option>
-              <option value="g4b-light">g4b-light </option>
-              <option value="g4b-dark">g4b-dark</option>
+              <option value="marine-light">marine-light </option>
+              <option value="marine-dark">marine-dark</option>
               <option value="skeleton-light">skeleton-light</option>
+              <option value="coral-light">coral-light</option>
             </select>
             <div id="canvas-root">
               <Title />
@@ -74,19 +75,6 @@ const preview: Preview = {
           </div>
         </>
       ),
-    },
-    backgrounds: {
-      default: 'g4b-light',
-      values: [
-        {
-          name: 'g4b-light',
-          value: '#f6f7f8',
-        },
-        {
-          name: 'skeleton-light',
-          value: '#f6f7f8',
-        },
-      ],
     },
   },
 };

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -22,16 +22,19 @@ package のインストール後は適切な箇所にインポートして使っ
 
 ### テーマ
 
-デフォルトで g4b-light テーマになっています。テーマをスイッチしたい場合は、任意の箇所に `data-theme='g4b-light/g4b-dark/skeleton-light'` を追加してください。
+デフォルトで marine-light テーマになっています。テーマをスイッチしたい場合は、任意の箇所に `data-theme='marine-light/marine-dark/skeleton-light/coral-light'` を追加してください。
 
 ```tsx
 <body>
   <div>
-    <Button>g4b-light Button</Button>
-    <div data-theme="g4b-dark">
-      <Button>g4b-dark Button</Button>
+    <Button>marine-light Button</Button>
+    <div data-theme="marine-dark">
+      <Button>marine-dark Button</Button>
       <div data-theme="skeleton-light">
         <Button>skeleton-light Button</Button>
+        <div data-theme="coral-light">
+          <Button>coral-light Button</Button>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要

* テーマ名を g4b => marine にリネームしつつ、coral-light を追加

## スクリーンショット


## ユーザ影響

* g4b-light, g4b-dark で以下のように明示的にテーマ指定してる場合は、それを marine-light, marine-dark に変更してください
    * skeleton-light は影響なしです
    * g4b-light をデフォルト利用してる場合は影響なしです

```html
// 変更前
<div data-theme="g4b-dark">
    <button class="ab-Button">g4b-dark Button</button>
    <div data-theme="g4b-light">
        <button class="ab-Button">g4b-light Button</button>
    </div>
</div>

// 変更後
<div data-theme="marine-dark">
    <button class="ab-Button">marine-dark Button</button>
    <div data-theme="marine-light">
        <button class="ab-Button">marine-light Button</button>
    </div>
</div>
```

* coral-light は追加なので影響なしです