### PR TITLE
[DesignToken] style-dictionary の update でデザイントークンがうまく吐き出せてない問題を修正

### DIFF
--- a/.changeset/eight-wings-kneel.md
+++ b/.changeset/eight-wings-kneel.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-design-tokens": patch
+---
+
+[fix] StyleDictionary update でトークンがうまく CSS に吐き出せてない問題を修正


### PR DESCRIPTION
## 概要

* デザイントークンは CSS variables として吐き出しているが、それが動いてない部分があったので修正

## スクリーンショット

## ユーザ影響

* なし
