### PR TITLE
[DesignToken] esm import が出来なくなっていたので修正

### DIFF
--- a/.changeset/tiny-masks-like.md
+++ b/.changeset/tiny-masks-like.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-design-tokens": patch
+---
+
+[fix] JavaScript の import がうまく出来ない問題を修正

--- a/packages/designTokens/build.sh
+++ b/packages/designTokens/build.sh
@@ -46,7 +46,7 @@ do
     }1'
   )
 
-  echo "export * as ${mjsFilename} from \"./${mjs_filename}\";" >> dist/mjs/index.js
+  echo "export * as ${mjsFilename} from \"./${mjs_filename}.js\";" >> dist/mjs/index.js
 done
 
 ts_files=`find dist/types -type f -name "*.d.ts"`


### PR DESCRIPTION
## 概要

* esm import が出来なくなっていたので修正

## スクリーンショット



## ユーザ影響

* なし
