### PR TITLE
[DesignToken] esm import するときに、marineLight.defaut.semantics のように default をつけないといけない問題を修正

### DIFF
--- a/packages/designTokens/build.sh
+++ b/packages/designTokens/build.sh
@@ -46,7 +46,7 @@ do
     }1'
   )
 
-  echo "export * as ${mjsFilename} from \"./${mjs_filename}.js\";" >> dist/mjs/index.js
+  echo "export { default as ${mjsFilename} } from \"./${mjs_filename}.js\";" >> dist/mjs/index.js
 done
 
 ts_files=`find dist/types -type f -name "*.d.ts"`

--- a/packages/designTokens/package.json
+++ b/packages/designTokens/package.json
@@ -11,7 +11,8 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "require": "./dist/cjs/index.js",
-      "import": "./dist/mjs/index.js"
+      "import": "./dist/mjs/index.js",
+      "default": "./dist/mjs/index.js"
     },
     "./css/*": "./dist/css/*",
     "./scss/*": "./dist/scss/*"


### PR DESCRIPTION
## 概要

* DesignToken を esm import するときに以下のように import しないといけなかった

```ts
import { marineLight } from "@giftee/abukuma-design-tokens";

marineLight.default.global;
```

* default をつけずに import できるように変更

## スクリーンショット


## ユーザ影響

* なし
