### PR TITLE
[css]spacingにレスポンシブ対応を追加

### DIFF
--- a/.changeset/tame-paws-slide.md
+++ b/.changeset/tame-paws-slide.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[feature:utility] spacing (margin/padding) にレスポンシブ対応を追加

--- a/packages/css/src/utilities/spacing/index.scss
+++ b/packages/css/src/utilities/spacing/index.scss
@@ -1,50 +1,56 @@
 @use '../../variables' as variables;
+@use '../../designTokens' as css-design-tokens;
 
-@each $spaceKey, $spaceValue in variables.$spacers {
-  .ab-p-#{$spaceKey} {
-    padding: #{$spaceValue};
-  }
-  .ab-px-#{$spaceKey} {
-    padding-left: #{$spaceValue};
-    padding-right: #{$spaceValue};
-  }
-  .ab-py-#{$spaceKey} {
-    padding-top: #{$spaceValue};
-    padding-bottom: #{$spaceValue};
-  }
-  .ab-m-#{$spaceKey} {
-    margin: #{$spaceValue};
-  }
-  .ab-mx-#{$spaceKey} {
-    margin-left: #{$spaceValue};
-    margin-right: #{$spaceValue};
-  }
-  .ab-my-#{$spaceKey} {
-    margin-top: #{$spaceValue};
-    margin-bottom: #{$spaceValue};
-  }
+@each $breakpoint, $variant in css-design-tokens.$responsive-variants {
+  @include css-design-tokens.breakpoint($breakpoint) {
+    @each $spaceKey, $spaceValue in variables.$spacers {
+      .ab#{$variant}-p-#{$spaceKey} {
+        padding: #{$spaceValue};
+      }
+      .ab#{$variant}-px-#{$spaceKey} {
+        padding-left: #{$spaceValue};
+        padding-right: #{$spaceValue};
+      }
+      .ab#{$variant}-py-#{$spaceKey} {
+        padding-top: #{$spaceValue};
+        padding-bottom: #{$spaceValue};
+      }
+      .ab#{$variant}-m-#{$spaceKey} {
+        margin: #{$spaceValue};
+      }
+      .ab#{$variant}-mx-#{$spaceKey} {
+        margin-left: #{$spaceValue};
+        margin-right: #{$spaceValue};
+      }
+      .ab#{$variant}-my-#{$spaceKey} {
+        margin-top: #{$spaceValue};
+        margin-bottom: #{$spaceValue};
+      }
 
-  @each $sideKey, $sideShorthand in variables.$sides {
-    .ab-p#{$sideShorthand}-#{$spaceKey} {
-      padding-#{$sideKey}: #{$spaceValue};
+      @each $sideKey, $sideShorthand in variables.$sides {
+        .ab#{$variant}-p#{$sideShorthand}-#{$spaceKey} {
+          padding-#{$sideKey}: #{$spaceValue};
+        }
+        .ab#{$variant}-m#{$sideShorthand}-#{$spaceKey} {
+          margin-#{$sideKey}: #{$spaceValue};
+        }
+      }
     }
-    .ab-m#{$sideShorthand}-#{$spaceKey} {
-      margin-#{$sideKey}: #{$spaceValue};
+
+    // margin auto（autoはspace mapにはないので個別に対応）
+    .ab#{$variant}-m-auto {
+      margin: auto;
     }
-  }
-}
 
-.ab-m-auto {
-  margin: auto;
-}
+    .ab#{$variant}-mx-auto {
+      margin-left: auto;
+      margin-right: auto;
+    }
 
-.ab-mx-auto {
-  margin-right: auto;
-  margin-left: auto;
-}
-
-@each $sideKey, $sideShorthand in variables.$sides {
-  .ab-m#{$sideShorthand}-auto {
-    margin-#{$sideKey}: auto;
+    @each $sideKey, $sideShorthand in variables.$sides {
+      .ab#{$variant}-m#{$sideShorthand}-auto {
+        margin-#{$sideKey}: auto;
+      }
+    }
   }
 }

--- a/packages/css/src/utilities/spacing/stories/Responsive.stories.ts
+++ b/packages/css/src/utilities/spacing/stories/Responsive.stories.ts
@@ -1,0 +1,27 @@
+import { meta } from './shared';
+import type { Story } from './shared';
+
+export default {
+  ...meta,
+  title: 'Utility/Spacing/Responsive',
+};
+
+export const Responsive: Story = {
+  render: (_args) => {
+    return `
+<div style="display:flex; flex-wrap: wrap;">
+  <div style="background-color: blue; height: 100%;">
+    <div class="ab-sm-p-2 ab-md-p-4 ab-lg-p-8 ab-xl-p-16 ab-m-1" style="background-color: red">responsive</div>
+  </div>
+</div>
+`;
+  },
+  args: {},
+  parameters: {
+    pseudo: {
+      hover: '#hover',
+      active: '#active',
+      focus: '#focus',
+    },
+  },
+};


### PR DESCRIPTION
## 概要

<!-- 変更内容を明記してください -->
spacingにレスポンシブ対応を入れました。

## スクリーンショット
* ab-md-p-8、ab-md-m-8で検証しています。
<!-- スクリーンショットが必要であれば貼り付けてください -->
<img width="300" alt="スクリーンショット 2025-05-07 14 09 54" src="https://github.com/user-attachments/assets/6e2a6db7-bd15-48fe-b699-1a690d000af4" />

* ab-sm-p-4、ab-sm-m-4で検証しています。
<img width="300" alt="スクリーンショット 2025-05-07 14 09 49" src="https://github.com/user-attachments/assets/f4037118-c7b5-4311-948c-8c88b4b41447" />

動画はこちら

https://github.com/user-attachments/assets/99720492-d4bc-40a3-8e58-c4a7d6c8b6aa

ストーリーブックでも確認しました。

https://github.com/user-attachments/assets/b3a551e0-f7d9-467f-9dab-393fb56d95d6



## ユーザ影響

<!-- 見た目の変更なら前後のスクリーンショットを、breaking change なら migration step を書いてください -->
