### PR TITLE
[CSS] Textfield/Select の label と input の margin を 16px => 8px に変更

### DIFF
--- a/.changeset/beige-nails-check.md
+++ b/.changeset/beige-nails-check.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[change:Textfield/Select] label と input の margin を 16px から 8px に変更

--- a/packages/css/src/components/textfield/index.scss
+++ b/packages/css/src/components/textfield/index.scss
@@ -32,7 +32,7 @@
     display: flex;
     align-items: center;
     gap: var(--ab-semantic-spacing-2);
-    margin-bottom: var(--ab-semantic-spacing-4);
+    margin-bottom: var(--ab-semantic-spacing-2);
     font-size: css-design-tokens.$font-size-body-m;
     color: var(--ab-semantic-color-text-default);
   }


### PR DESCRIPTION
## 概要

* Textfield/Select の label と input の margin を 16px => 8px に変更する

## スクリーンショット

* Textfield
![スクリーンショット 2025-05-15 14 12 22](https://github.com/user-attachments/assets/0286dffc-0d8c-413e-97ba-09c9cebe1320)

* Select
![スクリーンショット 2025-05-15 14 12 49](https://github.com/user-attachments/assets/4512f19e-982b-4123-a7b9-9ba26c60c82a)

## ユーザ影響

* Textfield/Select の label と input の margin がかわり、見た目が微妙に変わる
