### PR TITLE
[CSS] Button フォーカス時に outline を付与しキーボード操作のアクセシビリティを高める

### DIFF
--- a/.changeset/cold-clouds-bow.md
+++ b/.changeset/cold-clouds-bow.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[feat:Button] フォーカス時にブランドカラーの outline を付与（アクセシビリティ対応）

--- a/packages/css/src/components/button/index.scss
+++ b/packages/css/src/components/button/index.scss
@@ -175,6 +175,8 @@
     color: var(--button-focus-visible-color);
     background-color: var(--button-focus-visible-background-color);
     border-color: var(--button-focus-visible-border-color);
+    outline: 2px solid var(--ab-semantic-color-border-brand);
+    outline-offset: 2px;
   }
 
   &:active {


### PR DESCRIPTION
## 概要

* Button フォーカス時に outline がついていない
<img width="458" alt="スクリーンショット 2025-05-17 23 20 12" src="https://github.com/user-attachments/assets/bed92082-9e7b-4787-a283-06f2f0b986f0" />

* それにより、キーボード操作で視認性が悪くアクセシビリティが悪い
* よって、フォーカス時に outline をつける

## スクリーンショット

<img width="428" alt="スクリーンショット 2025-05-17 23 23 18" src="https://github.com/user-attachments/assets/b534ac16-abe1-4134-a1ab-f04598294379" />

## ユーザ影響

* フォーカス時に上記のような outline がつく
