### PR TITLE
[React] Button が disabled の時に aria-disabled を付加

### DIFF
--- a/.changeset/slow-lands-talk.md
+++ b/.changeset/slow-lands-talk.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-react": patch
+---
+
+[enhance:Button] disabled 時に aria-disabled を付加

--- a/packages/react/src/components/button/Index.tsx
+++ b/packages/react/src/components/button/Index.tsx
@@ -17,7 +17,7 @@ type ElementRefs = ElementRef<'button'> | ElementRef<'a'>;
 
 export const Button = forwardRef<ElementRefs, ButtonProps>(
   (
-    { children, className, variant, size, component, ...rest },
+    { children, className, variant, size, component, disabled, ...rest },
     forwardedRef,
   ) => {
     const classes = classNames(
@@ -30,8 +30,16 @@ export const Button = forwardRef<ElementRefs, ButtonProps>(
     const defaultRootNode = rest.href ? 'a' : 'button';
     const RootNode = component ? component : defaultRootNode;
 
+    const ariaDisabled = !!disabled;
+
     return (
-      <RootNode className={classes} ref={forwardedRef} {...rest}>
+      <RootNode
+        className={classes}
+        ref={forwardedRef}
+        disabled={disabled}
+        aria-disabled={ariaDisabled}
+        {...rest}
+      >
         {children}
       </RootNode>
     );


### PR DESCRIPTION
## 概要

* Button が disabled の時に aria-disabled が負荷されておらず、button タグ以外で生成されると disabled であることが認識できない
* よって、aria-disabled を付加

## スクリーンショット

* なし

## ユーザ影響

* 特になし
