### PR TITLE
[CSS] Date Picker コンポーネントを追加

### DIFF
--- a/.changeset/old-clowns-sort.md
+++ b/.changeset/old-clowns-sort.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[Add:DatePicker] Date Picker コンポーネントを追加

--- a/packages/css/src/components/datepicker/index.scss
+++ b/packages/css/src/components/datepicker/index.scss
@@ -1,0 +1,48 @@
+@use '../icon';
+@use '../textfield';
+
+$calender-url: 'data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTQgMTYiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTQgMEM0LjUzMTI1IDAgNSAwLjQ2ODc1IDUgMVYySDlWMUM5IDAuNDY4NzUgOS40Mzc1IDAgMTAgMEMxMC41MzEyIDAgMTEgMC40Njg3NSAxMSAxVjJIMTIuNUMxMy4zMTI1IDIgMTQgMi42ODc1IDE0IDMuNVY1SDBWMy41QzAgMi42ODc1IDAuNjU2MjUgMiAxLjUgMkgzVjFDMyAwLjQ2ODc1IDMuNDM3NSAwIDQgMFpNMCA2SDE0VjE0LjVDMTQgMTUuMzQzOCAxMy4zMTI1IDE2IDEyLjUgMTZIMS41QzAuNjU2MjUgMTYgMCAxNS4zNDM4IDAgMTQuNVY2Wk0yIDguNVY5LjVDMiA5Ljc4MTI1IDIuMjE4NzUgMTAgMi41IDEwSDMuNUMzLjc1IDEwIDQgOS43ODEyNSA0IDkuNVY4LjVDNCA4LjI1IDMuNzUgOCAzLjUgOEgyLjVDMi4yMTg3NSA4IDIgOC4yNSAyIDguNVpNNiA4LjVWOS41QzYgOS43ODEyNSA2LjIxODc1IDEwIDYuNSAxMEg3LjVDNy43NSAxMCA4IDkuNzgxMjUgOCA5LjVWOC41QzggOC4yNSA3Ljc1IDggNy41IDhINi41QzYuMjE4NzUgOCA2IDguMjUgNiA4LjVaTTEwLjUgOEMxMC4yMTg4IDggMTAgOC4yNSAxMCA4LjVWOS41QzEwIDkuNzgxMjUgMTAuMjE4OCAxMCAxMC41IDEwSDExLjVDMTEuNzUgMTAgMTIgOS43ODEyNSAxMiA5LjVWOC41QzEyIDguMjUgMTEuNzUgOCAxMS41IDhIMTAuNVpNMiAxMi41VjEzLjVDMiAxMy43ODEyIDIuMjE4NzUgMTQgMi41IDE0SDMuNUMzLjc1IDE0IDQgMTMuNzgxMiA0IDEzLjVWMTIuNUM0IDEyLjI1IDMuNzUgMTIgMy41IDEySDIuNUMyLjIxODc1IDEyIDIgMTIuMjUgMiAxMi41Wk02LjUgMTJDNi4yMTg3NSAxMiA2IDEyLjI1IDYgMTIuNVYxMy41QzYgMTMuNzgxMiA2LjIxODc1IDE0IDYuNSAxNEg3LjVDNy43NSAxNCA4IDEzLjc4MTIgOCAxMy41VjEyLjVDOCAxMi4yNSA3Ljc1IDEyIDcuNSAxMkg2LjVaTTEwIDEyLjVWMTMuNUMxMCAxMy43ODEyIDEwLjIxODggMTQgMTAuNSAxNEgxMS41QzExLjc1IDE0IDEyIDEzLjc4MTIgMTIgMTMuNVYxMi41QzEyIDEyLjI1IDExLjc1IDEyIDExLjUgMTJIMTAuNUMxMC4yMTg4IDEyIDEwIDEyLjI1IDEwIDEyLjVaIiBmaWxsPSIjNEU1QjYxIi8+Cjwvc3ZnPgo=';
+
+.ab-DatePicker {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+  width: 100%;
+
+  &-input {
+    @extend .ab-Textfield-input;
+
+    align-items: center;
+    width: 100%;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    position: relative;
+
+    &::-webkit-calendar-picker-indicator {
+      background: transparent;
+      z-index: 1;
+    }
+
+    &::after {
+      content: '';
+      background-image: url($calender-url);
+      background-repeat: no-repeat;
+      background-size: contain;
+      background-position: 0 0;
+      width: 16px;
+      height: 16px;
+      position: absolute;
+      top: 50%;
+      right: var(--ab-semantic-spacing-2);
+      transform: translateY(-50%);
+      cursor: pointer;
+    }
+  }
+}
+
+.ab-DatePicker {
+  &:has(.ab-DatePicker-input:disabled) {
+    pointer-events: none;
+  }
+}

--- a/packages/css/src/components/datepicker/stories/State.stories.ts
+++ b/packages/css/src/components/datepicker/stories/State.stories.ts
@@ -1,0 +1,86 @@
+import { meta } from './shared';
+import type { Story } from './shared';
+
+export default {
+  ...meta,
+  title: 'Component/DatePicker/State',
+};
+
+export const State: Story = {
+  render: (args) => {
+    return `
+<div id="default" class="ab-Textfield ab-mb-8">
+  <label for="default" class="ab-Textfield-label">
+    Default
+    ${args.required ? `<div class="ab-StatusLabel">必須</div>` : ''}
+  </label>
+  <span class="ab-DatePicker">
+    <input type="date" name="default" id="default" class="ab-DatePicker-input" />
+  </span>
+  <div class="ab-Textfield-helptext">default</div>
+</div>
+<div id="hover" class="ab-Textfield ab-mb-8">
+  <label for="hover" class="ab-Textfield-label">
+    Hover
+    ${args.required ? `<div class="ab-StatusLabel">必須</div>` : ''}
+  </label>
+  <span class="ab-DatePicker">
+    <input type="date" name="hover" id="hover" class="ab-DatePicker-input" />
+  </span>
+  <div class="ab-Textfield-helptext">hover</div>
+</div>
+<div id="active" class="ab-Textfield ab-mb-8">
+  <label for="active" class="ab-Textfield-label">
+    Active
+    ${args.required ? `<div class="ab-StatusLabel">必須</div>` : ''}
+  </label>
+  <span class="ab-DatePicker">
+    <input type="date" name="active" id="active" class="ab-DatePicker-input" />
+  </span>
+  <div class="ab-Textfield-helptext">active</div>
+</div>
+<div id="focus" class="ab-Textfield ab-mb-8">
+  <label for="focus" class="ab-Textfield-label">
+    Focus
+    ${args.required ? `<div class="ab-StatusLabel">必須</div>` : ''}
+  </label>
+  <span class="ab-DatePicker">
+    <input type="date" name="focus" id="focus" class="ab-DatePicker-input" />
+  </span>
+  <div class="ab-Textfield-helptext">focus</div>
+</div>
+<div class="ab-Textfield is-disabled ab-mb-8">
+  <label for="disabled" class="ab-Textfield-label">
+    Disabled
+    ${args.required ? `<div class="ab-StatusLabel">必須</div>` : ''}
+  </label>
+  <span class="ab-DatePicker">
+    <input type="date" name="disabled" id="disabled" disabled class="ab-DatePicker-input" />
+  </span>
+  <div class="ab-Textfield-helptext">disabled</div>
+</div>
+<div id="error" class="ab-Textfield is-error ab-mb-8">
+  <label for="error" class="ab-Textfield-label">
+    Error
+    ${args.required ? `<div class="ab-StatusLabel">必須</div>` : ''}
+  </label>
+  <span class="ab-DatePicker">
+    <input type="date" name="error" id="error" class="ab-DatePicker-input" />
+  </span>
+  <div class="ab-Textfield-error-message">error</div>
+  <div class="ab-Textfield-error-message">error</div>
+  <div class="ab-Textfield-helptext">helptext</div>
+</div>
+  `;
+  },
+  args: {
+    required: false,
+  },
+  parameters: {
+    pseudo: {
+      hover: '#hover',
+      active: '#active',
+      focus: '#focus',
+    },
+  },
+};

--- a/packages/css/src/components/datepicker/stories/shared.ts
+++ b/packages/css/src/components/datepicker/stories/shared.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/html';
+
+export type Args = {
+  required: boolean;
+  disabled?: boolean;
+};
+
+export const meta: Meta<Args> = {
+  argTypes: {
+    required: {
+      type: 'boolean',
+    },
+    disabled: {
+      type: 'boolean',
+    },
+  },
+  parameters: {},
+};
+
+export type Story = StoryObj<Args>;

--- a/packages/css/src/components/index.scss
+++ b/packages/css/src/components/index.scss
@@ -3,6 +3,7 @@
 @forward './button/index';
 @forward './circularprogress/index';
 @forward './checkbox/index';
+@forward './datepicker/index';
 @forward './divider/index';
 @forward './dropzone/index';
 @forward './fieldset/index';


### PR DESCRIPTION
## 概要

* Date Picker コンポーネントを追加
* カレンダー UI はブラウザのネイティブ利用。理由は以下
  * アクセシビリティ的にネイティブが良い
  * スマホなどではネイティブの方が使い心地が良い

## スクリーンショット

![スクリーンショット 2025-06-26 16 09 27](https://github.com/user-attachments/assets/a1b68bfb-3b08-4c55-8b3f-324cd3b334e7)


## ユーザ影響

* 追加
