### PR TITLE
[DesignToken] ブランドカラーで contain されている場合、hover,active,focus の時に色が薄くなるのではなく濃くなるようにした

### DIFF
--- a/.changeset/sixty-pandas-run.md
+++ b/.changeset/sixty-pandas-run.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-design-tokens": minor
+---
+
+[change] ブランドカラーで contain されている場合、hover,active,focus の時に色が薄くなるのではなく濃くなるようにした

--- a/packages/designTokens/tokens/globals/index.tokens.json
+++ b/packages/designTokens/tokens/globals/index.tokens.json
@@ -4,7 +4,7 @@
       "white": {
         "50": { "$type": "color", "$value": "rgba(255, 255, 255, 0.05)" },
         "200": { "$type": "color", "$value": "rgba(255, 255, 255, 0.25)" },
-        "400": { "$type": "color", "$value": "rgba(255, 255, 255, 0.5)" },
+        "400": { "$type": "color", "$value": "rgba(255, 255, 255, 0.50)" },
         "600": { "$type": "color", "$value": "rgba(255, 255, 255, 0.75)" },
         "800": { "$type": "color", "$value": "#ffffff" }
       },
@@ -28,16 +28,6 @@
         "900": { "$type": "color", "$value": "#002a43" }
       },
       "coral": {
-        "50": { "$type": "color", "$value": "#faf6f5" },
-        "70": { "$type": "color", "$value": "#f7ebe8" },
-        "100": { "$type": "color", "$value": "#fbe1da" },
-        "200": { "$type": "color", "$value": "#f9cec3" },
-        "400": { "$type": "color", "$value": "#f4ac99" },
-        "600": { "$type": "color", "$value": "#f08b71" },
-        "800": { "$type": "color", "$value": "#7b3522" },
-        "900": { "$type": "color", "$value": "#502419" }
-      },
-      "forest": {
         "50": { "$type": "color", "$value": "#faf6f5" },
         "70": { "$type": "color", "$value": "#f7ebe8" },
         "100": { "$type": "color", "$value": "#fbe1da" },
@@ -97,7 +87,7 @@
         "slate": {
           "10": { "$type": "color", "$value": "rgba(35, 35, 35, 0.1)" },
           "20": { "$type": "color", "$value": "rgba(35, 35, 35, 0.2)" },
-          "70": { "$type": "color", "$value": "rgba(35, 35, 35, 0.69999)" }
+          "70": { "$type": "color", "$value": "rgba(35, 35, 35, 0.70)" }
         }
       }
     },

--- a/packages/designTokens/tokens/semantics/brands/coral-light/index.tokens.json
+++ b/packages/designTokens/tokens/semantics/brands/coral-light/index.tokens.json
@@ -2,6 +2,7 @@
   "semantic": {
     "color": {
       "brand": {
+        "darkest": { "$type": "color", "$value": "{global.color.sepia.900}" },
         "dark": { "$type": "color", "$value": "{global.color.sepia.800}" },
         "default": { "$type": "color", "$value": "{global.color.sepia.600}" },
         "light": { "$type": "color", "$value": "{global.color.sepia.400}" },
@@ -69,15 +70,15 @@
         },
         "hover-on-brand": {
           "$type": "color",
-          "$value": "{semantic.color.brand.light}"
+          "$value": "{semantic.color.brand.dark}"
         },
         "focus-on-brand": {
           "$type": "color",
-          "$value": "{semantic.color.brand.light}"
+          "$value": "{semantic.color.brand.dark}"
         },
         "pressed-on-brand": {
           "$type": "color",
-          "$value": "{semantic.color.brand.lighter}"
+          "$value": "{semantic.color.brand.darkest}"
         },
         "hover-on-neutral": {
           "$type": "color",

--- a/packages/designTokens/tokens/semantics/brands/marine-dark/index.tokens.json
+++ b/packages/designTokens/tokens/semantics/brands/marine-dark/index.tokens.json
@@ -2,6 +2,7 @@
   "semantic": {
     "color": {
       "brand": {
+        "darkest": { "$type": "color", "$value": "{global.color.marine.900}" },
         "dark": { "$type": "color", "$value": "{global.color.marine.800}" },
         "default": { "$type": "color", "$value": "{global.color.marine.600}" },
         "light": { "$type": "color", "$value": "{global.color.marine.400}" },

--- a/packages/designTokens/tokens/semantics/brands/marine-light/index.tokens.json
+++ b/packages/designTokens/tokens/semantics/brands/marine-light/index.tokens.json
@@ -2,6 +2,7 @@
   "semantic": {
     "color": {
       "brand": {
+        "darkest": { "$type": "color", "$value": "{global.color.marine.900}" },
         "dark": { "$type": "color", "$value": "{global.color.marine.800}" },
         "default": { "$type": "color", "$value": "{global.color.marine.600}" },
         "light": { "$type": "color", "$value": "{global.color.marine.400}" },
@@ -69,15 +70,15 @@
         },
         "hover-on-brand": {
           "$type": "color",
-          "$value": "{semantic.color.brand.light}"
+          "$value": "{semantic.color.brand.dark}"
         },
         "focus-on-brand": {
           "$type": "color",
-          "$value": "{semantic.color.brand.light}"
+          "$value": "{semantic.color.brand.dark}"
         },
         "pressed-on-brand": {
           "$type": "color",
-          "$value": "{semantic.color.brand.lighter}"
+          "$value": "{semantic.color.brand.darkest}"
         },
         "hover-on-neutral": {
           "$type": "color",

--- a/packages/designTokens/tokens/semantics/brands/skeleton-light/index.tokens.json
+++ b/packages/designTokens/tokens/semantics/brands/skeleton-light/index.tokens.json
@@ -2,6 +2,7 @@
   "semantic": {
     "color": {
       "brand": {
+        "darkest": { "$type": "color", "$value": "{global.color.steel.900}" },
         "dark": { "$type": "color", "$value": "{global.color.steel.800}" },
         "default": { "$type": "color", "$value": "{global.color.steel.600}" },
         "light": { "$type": "color", "$value": "{global.color.steel.400}" },
@@ -69,15 +70,15 @@
         },
         "hover-on-brand": {
           "$type": "color",
-          "$value": "{semantic.color.brand.light}"
+          "$value": "{semantic.color.brand.dark}"
         },
         "focus-on-brand": {
           "$type": "color",
-          "$value": "{semantic.color.brand.light}"
+          "$value": "{semantic.color.brand.dark}"
         },
         "pressed-on-brand": {
           "$type": "color",
-          "$value": "{semantic.color.brand.lighter}"
+          "$value": "{semantic.color.brand.darkest}"
         },
         "hover-on-neutral": {
           "$type": "color",


### PR DESCRIPTION
## 概要

* ブランドカラーで contain されている場合、hover, active, focus 時は色が薄くなっていた
* しかし、それだとコントラスト比が小さく視認性が悪かった
* そこで、色が濃くなるように変更

## スクリーンショット

![スクリーンショット 2025-06-26 21 45 34](https://github.com/user-attachments/assets/8e779991-590e-436b-a9df-31225698eee2)


## ユーザ影響

* hover, active, focus で色が変わる以下のコンポーネントのデザインが↑のようになります
  * Button, Checkbox, IconButton, Switch
