### PR TITLE
[CSS] focus 時に outline をつけて視認性を向上する

### DIFF
--- a/.changeset/moody-poets-switch.md
+++ b/.changeset/moody-poets-switch.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[change] 視認性向上のために、focus 時に outline がつくように変更

--- a/packages/css/src/components/button/index.scss
+++ b/packages/css/src/components/button/index.scss
@@ -25,6 +25,7 @@
   --button-focus-visible-border-color: var(
     --ab-semantic-color-background-focus-on-brand
   );
+  --button-focus-visible-outline-color: var(--ab-semantic-color-border-brand);
   --button-active-color: var(--ab-semantic-color-text-contrast);
   --button-active-background-color: var(
     --ab-semantic-color-background-pressed-on-brand
@@ -53,6 +54,7 @@
     --ab-semantic-color-background-focus-on-neutral
   );
   --button-focus-visible-border-color: var(--ab-semantic-color-border-brand);
+  --button-focus-visible-outline-color: var(--ab-semantic-color-border-brand);
   --button-active-color: var(--ab-semantic-color-text-brand);
   --button-active-background-color: var(
     --ab-semantic-color-background-pressed-on-neutral
@@ -74,6 +76,9 @@
     --ab-semantic-color-background-focus-on-negative
   );
   --button-focus-visible-border-color: var(--ab-semantic-color-border-negative);
+  --button-focus-visible-outline-color: var(
+    --ab-semantic-color-border-negative
+  );
   --button-active-color: var(--ab-semantic-color-text-negative);
   --button-active-background-color: var(
     --ab-semantic-color-background-pressed-on-negative
@@ -99,6 +104,7 @@
     --ab-semantic-color-background-focus-on-neutral
   );
   --button-focus-visible-border-color: var(--ab-semantic-color-border-light);
+  --button-focus-visible-outline-color: var(--ab-semantic-color-border-brand);
   --button-active-color: var(--ab-semantic-color-text-default);
   --button-active-background-color: var(
     --ab-semantic-color-background-pressed-on-neutral
@@ -124,6 +130,7 @@
     --ab-semantic-color-background-focus-on-neutral
   );
   --button-focus-visible-border-color: none;
+  --button-focus-visible-outline-color: var(--ab-semantic-color-border-brand);
   --button-active-color: var(--ab-semantic-color-text-brand);
   --button-active-background-color: var(
     --ab-semantic-color-background-pressed-on-neutral
@@ -175,6 +182,8 @@
     color: var(--button-focus-visible-color);
     background-color: var(--button-focus-visible-background-color);
     border-color: var(--button-focus-visible-border-color);
+    outline: solid var(--button-focus-visible-outline-color) 2px;
+    outline-offset: 2px;
   }
 
   &:active {

--- a/packages/css/src/components/radio/index.scss
+++ b/packages/css/src/components/radio/index.scss
@@ -118,6 +118,11 @@
   }
 
   &:focus {
+    .ab-Radio-radio {
+      outline: solid var(--ab-semantic-color-border-brand) 2px;
+      outline-offset: 2px;
+    }
+
     .ab-Radio-radio,
     .ab-Radio-input:checked ~ .ab-Radio-radio {
       background-color: var(--radio-radio-focus-background-color);

--- a/packages/css/src/components/textfield/index.scss
+++ b/packages/css/src/components/textfield/index.scss
@@ -61,6 +61,8 @@
 
     &:focus {
       border-color: var(--textfield-input-focus-border-color);
+      outline: solid var(--ab-semantic-color-border-brand) 2px;
+      outline-offset: 2px;
     }
 
     &:active {


### PR DESCRIPTION
## 概要

* focus 時に outline はついていない
* 視認性が悪いので、outline をつける

## スクリーンショット

![スクリーンショット 2025-06-26 22 31 19](https://github.com/user-attachments/assets/7d01beb6-13d8-4149-bfbc-65f8de09f56d)


## ユーザ影響

* 以下のコンポーネントに focus 時に outline がつく
  * Button, IconButton, Radio, Textfield, Select, DatePicker, DateTimePicker
