### PR TITLE
[css] モーダル表示時に位置が先頭に戻る問題を修正

### DIFF
--- a/.changeset/tasty-bats-occur.md
+++ b/.changeset/tasty-bats-occur.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[fix:modal] モーダル表示時に位置が先頭に戻る問題を修正

--- a/packages/css/src/components/modal/index.scss
+++ b/packages/css/src/components/modal/index.scss
@@ -1,4 +1,5 @@
 .ab-Modal {
+  position: fixed;
   border: none;
   padding: var(--ab-semantic-spacing-0);
   border-radius: var(--ab-semantic-border-radius-md);


### PR DESCRIPTION
## 概要
モーダルを開いた時に表示位置が一番上に移動してしまうのを修正しました。
`dialog`に`position:absolute`が当たっているのが原因
(`createPortal`でダイアログをbodyの直下にすればそのままでもいけるかもと思って試してみましたが、`dialog-polyfill`の`position:absolute`が効いてしまっていると一番上に行ってしまいました。)

## スクリーンショット

<img width="525" alt="image" src="https://github.com/user-attachments/assets/a144697e-631e-4898-8613-3a776c302cb3" />


<img width="1090" alt="image" src="https://github.com/user-attachments/assets/223e87bc-8bf1-4772-9f65-1b937c944c2a" />

## ユーザ影響
現状

https://github.com/user-attachments/assets/bff4bdf3-5d51-4682-96a9-d886d7879a56

修正

https://github.com/user-attachments/assets/0dd2a59a-247c-4e75-b436-db3f978d8ca3



