### PR TITLE
[CSS] 視認性の向上のために、checkbox の focus 時に outline を入れる

### DIFF
--- a/.changeset/cool-nails-bet.md
+++ b/.changeset/cool-nails-bet.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[enhancement:Checkbox] Focus 時に outline を導入し、視認性を向上

--- a/packages/css/src/components/checkbox/index.scss
+++ b/packages/css/src/components/checkbox/index.scss
@@ -27,6 +27,7 @@ $checkmark-url: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOSIgd
   --checkbox-box-focus-checked-background-color: var(
     --ab-semantic-color-background-focus-on-brand
   );
+  --checkbox-box-focus-outline-color: var(--ab-semantic-color-border-brand);
   --checkbox-box-active-background-color: var(
     --ab-semantic-color-background-pressed-on-neutral
   );
@@ -138,10 +139,14 @@ $checkmark-url: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOSIgd
   &:focus {
     .ab-Checkbox-box {
       background-color: var(--checkbox-box-focus-background-color);
+      outline: solid var(--checkbox-box-focus-outline-color) 2px;
+      outline-offset: 2px;
     }
 
     .ab-Checkbox-input:checked ~ .ab-Checkbox-box {
       background-color: var(--checkbox-box-focus-checked-background-color);
+      outline: solid var(--checkbox-box-focus-outline-color) 2px;
+      outline-offset: 2px;
     }
   }
 


### PR DESCRIPTION
## 概要

* Checkbox コンポーネントは focus 時に focus されているか分かりにくい
* そこで、ブラウザの挙動と合わせるように outline を入れる

## スクリーンショット

<img width="166" height="169" alt="スクリーンショット 2025-09-16 8 58 12" src="https://github.com/user-attachments/assets/ddc445fa-0d14-4cf8-b757-c109c1da92a3" />

## ユーザ影響

* 特になし。見た目のみ
