### PR TITLE
[react]MenuCollapseItemのlabelプロパティをReactNodeに変更

### DIFF
--- a/.changeset/green-snakes-greet.md
+++ b/.changeset/green-snakes-greet.md
@@ -1,0 +1,6 @@
+---
+"@giftee/abukuma-react": patch
+---
+
+[feature:Menu] MenuCollapseItemのlabelプロパティをReactNodeに変更
+

--- a/packages/react/src/components/menu/Index.spec.tsx
+++ b/packages/react/src/components/menu/Index.spec.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { describe, test, expect, vi } from 'vitest';
 import '@testing-library/jest-dom';
+import { User } from '@/storyAssets/inlineSvgs';
 
 import {
   Root,
@@ -100,6 +101,32 @@ describe('Menu', () => {
     const collapseSummary = getByText('折りたたみメニュー');
     expect(collapseSummary).toBeInTheDocument();
     expect(collapseSummary.closest('.ab-Menu-item')).toBeInTheDocument();
+  });
+
+  test('アイコン付き折りたたみメニュー項目が正しくレンダリングされる', () => {
+    const { getByRole } = render(
+      <Root>
+        <CollapseItem
+          label={
+            <div className="ab-flex ab-flex-row ab-flex-justify-between ab-flex-items-center">
+              <User className="ab-Icon" />
+              <span className="ab-ml-2">アイコン付きメニュー</span>
+            </div>
+          }
+        >
+          <SubMenu>
+            <Item>
+              <ItemLabel>サブ項目</ItemLabel>
+            </Item>
+          </SubMenu>
+        </CollapseItem>
+      </Root>,
+    );
+
+    const menuButton = getByRole('button', { name: /アイコン付きメニュー/i });
+    const icon = menuButton.querySelector('svg.ab-Icon');
+    expect(menuButton).toBeInTheDocument();
+    expect(icon).toBeInTheDocument();
   });
 
   test('サブメニューが正しくレンダリングされる', () => {

--- a/packages/react/src/components/menu/Menu.stories.tsx
+++ b/packages/react/src/components/menu/Menu.stories.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@/index';
-import { AngleRight, User } from '@/storyAssets/inlineSvgs';
+import { AngleRight, User, CircleInfo } from '@/storyAssets/inlineSvgs';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta = {
@@ -184,53 +184,95 @@ export const Size: Story = {
 
 export const Collapsible: Story = {
   render: () => (
-    <div className="ab-p-2" style={{ width: '250px' }}>
-      <Menu.Root size="medium">
-        <Menu.Item>
-          <Menu.ItemLink href="#">
-            通常メニュー
-            <AngleRight className="ab-Icon ab-ml-auto" />
-          </Menu.ItemLink>
-        </Menu.Item>
-        <Menu.Item>
-          <Menu.ItemLink href="#">
-            通常メニュー
-            <AngleRight className="ab-Icon ab-ml-auto" />
-          </Menu.ItemLink>
-        </Menu.Item>
-        <Menu.CollapseItem label="開閉メニュー" defaultOpen={true}>
-          <Menu.SubMenu>
-            <Menu.Item>
-              <Menu.ItemLink href="#">
-                通常メニュー
-                <AngleRight className="ab-Icon ab-ml-auto" />
-              </Menu.ItemLink>
-            </Menu.Item>
-            <Menu.Item>
-              <Menu.ItemLink href="#">
-                通常メニュー
-                <AngleRight className="ab-Icon ab-ml-auto" />
-              </Menu.ItemLink>
-            </Menu.Item>
-          </Menu.SubMenu>
-        </Menu.CollapseItem>
-        <Menu.CollapseItem label="開閉メニュー" defaultOpen={false}>
-          <Menu.SubMenu>
-            <Menu.Item>
-              <Menu.ItemLink href="#">
-                通常メニュー
-                <AngleRight className="ab-Icon ab-ml-auto" />
-              </Menu.ItemLink>
-            </Menu.Item>
-            <Menu.Item>
-              <Menu.ItemLink href="#">
-                通常メニュー
-                <AngleRight className="ab-Icon ab-ml-auto" />
-              </Menu.ItemLink>
-            </Menu.Item>
-          </Menu.SubMenu>
-        </Menu.CollapseItem>
-      </Menu.Root>
+    <div className="ab-flex ab-gap-4">
+      <div className="ab-p-2" style={{ width: '250px' }}>
+        <Menu.Root size="medium">
+          <Menu.Item>
+            <Menu.ItemLink href="#">
+              通常メニュー
+              <AngleRight className="ab-Icon ab-ml-auto" />
+            </Menu.ItemLink>
+          </Menu.Item>
+          <Menu.CollapseItem label="開閉メニュー" defaultOpen={true}>
+            <Menu.SubMenu>
+              <Menu.Item>
+                <Menu.ItemLink href="#">
+                  通常メニュー
+                  <AngleRight className="ab-Icon ab-ml-auto" />
+                </Menu.ItemLink>
+              </Menu.Item>
+              <Menu.Item>
+                <Menu.ItemLink href="#">
+                  通常メニュー
+                  <AngleRight className="ab-Icon ab-ml-auto" />
+                </Menu.ItemLink>
+              </Menu.Item>
+            </Menu.SubMenu>
+          </Menu.CollapseItem>
+          <Menu.CollapseItem label="開閉メニュー" defaultOpen={false}>
+            <Menu.SubMenu>
+              <Menu.Item>
+                <Menu.ItemLink href="#">
+                  通常メニュー
+                  <AngleRight className="ab-Icon ab-ml-auto" />
+                </Menu.ItemLink>
+              </Menu.Item>
+            </Menu.SubMenu>
+          </Menu.CollapseItem>
+        </Menu.Root>
+      </div>
+      <div className="ab-p-2" style={{ width: '250px' }}>
+        <Menu.Root size="medium">
+          <Menu.Item>
+            <Menu.ItemLink href="#">
+              通常メニュー
+              <AngleRight className="ab-Icon ab-ml-auto" />
+            </Menu.ItemLink>
+          </Menu.Item>
+          <Menu.CollapseItem
+            label={
+              <div className="ab-flex ab-flex-row ab-flex-justify-between ab-flex-items-center">
+                <CircleInfo className="ab-Icon" />
+                <span className="ab-ml-2">ギフト購入</span>
+              </div>
+            }
+            defaultOpen={true}
+          >
+            <Menu.SubMenu>
+              <Menu.Item>
+                <Menu.ItemLink href="#">
+                  デジタルギフト
+                  <AngleRight className="ab-Icon ab-ml-auto" />
+                </Menu.ItemLink>
+              </Menu.Item>
+              <Menu.Item>
+                <Menu.ItemLink href="#">
+                  物理ギフト
+                  <AngleRight className="ab-Icon ab-ml-auto" />
+                </Menu.ItemLink>
+              </Menu.Item>
+            </Menu.SubMenu>
+          </Menu.CollapseItem>
+          <Menu.CollapseItem
+            label={
+              <div className="ab-flex ab-flex-row ab-flex-justify-between ab-flex-items-center">
+                <User className="ab-Icon" />
+                <span className="ab-ml-2">ユーザー管理</span>
+              </div>
+            }
+            defaultOpen={false}
+          >
+            <Menu.SubMenu>
+              <Menu.Item>
+                <Menu.ItemLink href="#">
+                  プロフィール
+                  <AngleRight className="ab-Icon ab-ml-auto" />
+                </Menu.ItemLink>
+              </Menu.Item>
+            </Menu.SubMenu>
+          </Menu.CollapseItem>
+        </Menu.Root>
+      </div>
     </div>
   ),
 };

--- a/packages/react/src/components/menu/MenuCollapseItem.tsx
+++ b/packages/react/src/components/menu/MenuCollapseItem.tsx
@@ -1,12 +1,12 @@
 import { forwardRef, useState } from 'react';
 import { classNames } from '@/utils/classNames';
-import type { ComponentPropsWithoutRef, ElementRef } from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, ReactNode } from 'react';
 
 export type MenuCollapseItemProps = ComponentPropsWithoutRef<'li'> & {
   /**
    * サブメニューラベル
    */
-  label: string;
+  label: ReactNode;
   /**
    * サブメニューのデフォルト開閉状態
    */


### PR DESCRIPTION
## 概要
`Menu.CollapseItem`コンポーネントの`label`プロパティの型定義をReactNodeに変更し、アイコンなどの要素を表示できるようにしました。

### 主な変更点
- `MenuCollapseItemProps`の`labelプロパティをReactNode型に変更
- `Menu.stories.tsx`にアイコン付きの使用例を追加
- アイコン機能のテストケースを追加


## スクリーンショット

<img width="266" height="76" alt="スクリーンショット 2025-09-26 14 54 23" src="https://github.com/user-attachments/assets/8548a3a5-c2ea-45d3-9c5b-4b2035c9f6da" />

## ユーザ影響
- **後方互換性**: `lebel`プロパティはstring型も受け入れるため、既存の実装に影響はありません
- **Breaking Changes**: なし
