### PR TITLE
[fix: statusLabel]–ab-semantic-color-text-defaulを–ab-semantic-color-text-defaultに修正

### DIFF
--- a/.changeset/nine-ideas-lay.md
+++ b/.changeset/nine-ideas-lay.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[fix: statusLabel]–ab-semantic-color-text-defaulを–ab-semantic-color-text-defaultに修正

--- a/packages/css/src/components/statuslabel/index.scss
+++ b/packages/css/src/components/statuslabel/index.scss
@@ -51,7 +51,7 @@
   --status-label-background: var(
     --ab-semantic-color-background-neutral-primary
   );
-  --status-label-color: var(--ab-semantic-color-text-defaul);
+  --status-label-color: var(--ab-semantic-color-text-default);
   --status-label-border-color: var(--ab-semantic-color-border-bold);
 }
 


### PR DESCRIPTION
## 概要
`.ab-StatusLabel-neutral`の`--ab-semantic-color-text-default`で末尾`t`が抜けていたため追加

## スクリーンショット
- --ab-semantic-color-text-defaultが適用されていることを確認済み
<img width="1144" height="255" alt="image" src="https://github.com/user-attachments/assets/15b2352c-c74b-4f9c-a227-9d3bf0ffc754" />


## ユーザ影響

- 特になし
