### PR TITLE
[CSS] エラー時の Dropzone の背景色を notice(白) から negative(赤) に修正

### DIFF
--- a/.changeset/yellow-spiders-fall.md
+++ b/.changeset/yellow-spiders-fall.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[fix:Dropzone] エラー時の背景色を白から薄い赤に修正

--- a/packages/css/src/components/dropzone/index.scss
+++ b/packages/css/src/components/dropzone/index.scss
@@ -96,7 +96,7 @@
 // Error
 .ab-Dropzone.is-error {
   border-color: var(--ab-semantic-color-border-negative);
-  background-color: var(--ab-semantic-color-background-notice-secondary);
+  background-color: var(--ab-semantic-color-background-negative-secondary);
 
   .ab-Dropzone-error {
     display: block;


### PR DESCRIPTION
## 概要

* エラー時の背景色が notice (白) になっていた
* エラーは negative (赤) を使うべきなので、それに修正する

## スクリーンショット

* 修正前

<img width="1452" height="584" alt="image" src="https://github.com/user-attachments/assets/ae9c5248-f93d-4ad8-b20f-d23d7d1c109e" />

* 修正後

<img width="390" height="145" alt="スクリーンショット 2025-10-28 9 48 17" src="https://github.com/user-attachments/assets/0a0d0f39-7e4d-46c6-ab60-9eabba923e3e" />


## ユーザ影響

* CSS/React ユーザどちらも、Dropzone のエラー時の背景色が変わります
