### PR TITLE
[css] Stepperのz-indexを適切な値に修正

### DIFF
--- a/.changeset/plenty-guests-melt.md
+++ b/.changeset/plenty-guests-melt.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[fix:stepper] z-index を修正

--- a/packages/css/src/components/stepper/index.scss
+++ b/packages/css/src/components/stepper/index.scss
@@ -75,7 +75,7 @@ $stepper-checkmark-url: 'data:image/svg+xml;base64,PHN2ZyBjbGFzcz0iYWItSWNvbiBhY
     color: var(--ab-semantic-color-text-secondary);
     font-size: css-design-tokens.$font-size-body-s;
     font-weight: var(--ab-semantic-typography-font-weight-bold);
-    z-index: css-design-tokens.$zindex-overlap;
+    z-index: 1;
   }
 
   &-label {


### PR DESCRIPTION
## 概要
Stepper コンポーネントの z-index が 5000 に設定されており、
モーダルよりも前面に表示されてしまう問題が発生していました。

本来、Stepper は他の要素の上に重ねて表示する必要はないため、
線要素（今回は擬似要素の`Stepper-item-passed:after`）より前に出ていれば十分です。
そのため、z-index を1に設定し、適切な表示順に修正しました。

issue
stepperのz-indexの修正
[#33338](https://github.com/giftee/ikedayama/issues/33338)

## スクリーンショット

|事例1|事例2|
|---|---|
|<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/6db9f5ae-1692-48fc-8a84-6659f4988b1f" />|<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/cc9734dc-28ae-4e42-baf6-3c6f478bff96" />|

## ユーザ影響

|before|after|
|---|---|
|<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/6db9f5ae-1692-48fc-8a84-6659f4988b1f" />|<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/960f33e3-62cd-47e2-8ab6-e07c120f7ec1" />|


|before|after|
|---|---|
|<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/cc9734dc-28ae-4e42-baf6-3c6f478bff96" />|<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/d2be3d7a-58a7-42f8-9fdc-7e63d35e3157" />|


表示も大丈夫そうです。
<img width="1197" height="798" alt="image" src="https://github.com/user-attachments/assets/a98d056f-68d9-4d66-a868-e3ca56ce6cfb" />

<img width="1293" height="802" alt="image" src="https://github.com/user-attachments/assets/832d7cdf-4954-47be-96f1-3a60c0ff274c" />
