### PR TITLE
[CSS] top_layer をサポートしていないブラウザで Modal が開けない問題を修正

### DIFF
--- a/.changeset/shaky-eels-melt.md
+++ b/.changeset/shaky-eels-melt.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+[fix:Modal] top_layer をサポートしていない古いブラウザで、Modal が開けない問題を修正

--- a/packages/css/src/components/modal/index.scss
+++ b/packages/css/src/components/modal/index.scss
@@ -5,8 +5,12 @@
   border-radius: var(--ab-semantic-border-radius-md);
   background-color: var(--ab-semantic-color-background-base);
   max-height: 100%;
-  width: 100%;
+  height: fit-content;
+  width: auto; // フォールバック
+  width: fit-content;
   overflow-y: auto;
+  inset: 0;
+  margin: auto;
 
   &::backdrop {
     background-color: rgba(35 35 35 / 70%);


### PR DESCRIPTION
## 概要

* top_layer をサポートしていないブラウザで Modal が開けない
  * 下記は edge 100

<img width="688" height="283" alt="スクリーンショット 2025-11-27 17 44 37" src="https://github.com/user-attachments/assets/e4fdc28f-43da-49e9-83df-2f492782952b" />

* top_layer がない場合、position: fixed で実装されているが、中央寄せされていないことが原因
  * 指定がないと既存 DOM 上の位置に表示されてしまい、下部に表示されている
* よって、inset: 0 と margin: auto を追加

## スクリーンショット

*   * edge 100 で検証
<img width="864" height="583" alt="スクリーンショット 2025-11-27 18 23 02" src="https://github.com/user-attachments/assets/e683932a-ab40-4a18-8d7c-119f571573c9" />


## ユーザ影響

* 古いブラウザを使っていたユーザで、modal が見えるようになります
