### PR TITLE
[css]Tableのcellのoverflowをvisibleに上書きするようなクラスを追加

### DIFF
--- a/.changeset/ten-pears-smash.md
+++ b/.changeset/ten-pears-smash.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": minor
+---
+
+Tableのcellのoverflowをvisibleに上書きするようなクラスを追加

--- a/packages/css/src/components/table/index.scss
+++ b/packages/css/src/components/table/index.scss
@@ -72,3 +72,11 @@
     }
   }
 }
+
+.ab-Table-overflow-visible {
+  & .ab-Table-body {
+    & .ab-Table-cell {
+      overflow: visible;
+    }
+  }
+}

--- a/packages/css/src/components/table/stories/OverflowVisible.stories.ts
+++ b/packages/css/src/components/table/stories/OverflowVisible.stories.ts
@@ -1,0 +1,109 @@
+import { meta } from './shared';
+import type { Story } from './shared';
+import GifteeBox from '../../../../story_assets/giftee-box.svg';
+
+export default {
+  ...meta,
+  title: 'Component/Table/OverflowVisible',
+};
+
+export const Bordered: Story = {
+  render: (_args) => {
+    return `
+<table class="ab-Table ab-Table-overflow-visible">
+  <thead class="ab-Table-head">
+    <tr>
+      <th
+        class="ab-Table-head-cell"
+        aria-sort="descending"
+        tabindex="0"
+      >
+        商品情報
+      </th>
+      <th class="ab-Table-head-cell" aria-sort="descending">価格</th>
+      <th class="ab-Table-head-cell">ギフト利用審査</th>
+      <th class="ab-Table-head-cell">最低発注数有無</th>
+      <th class="ab-Table-head-cell">有効期限</th>
+    </tr>
+  </thead>
+  <tbody class="ab-Table-body">
+    <tr class="ab-Table-body-row">
+      <td class="ab-Table-cell ab-flex ab-flex-column">
+        <span class="ab-text-body-xs ab-text-secondary">ギフティ</span>
+        <span class="ab-text-body-s">giftee Box</span>
+      </td>
+      <td class="ab-Table-cell">¥500</td>
+      <td class="ab-Table-cell">1〜2営業日</td>
+      <td class="ab-Table-cell">あり</td>
+      <td class="ab-Table-cell">
+        <span class="ab-Tooltip ab-Tooltip-top"
+          >１ヶ月後の月末
+          <span class="ab-Tooltip-description"
+            >テーブルからはみ出して要素を表示できます</span
+          >
+        </span>
+      </td>
+    </tr>
+    <tr class="ab-Table-body-row">
+      <td class="ab-Table-cell ab-flex ab-flex-items-center">
+        <img src="${GifteeBox}" class="ab-mr-2" style="height: 56px" />
+        <div class="ab-flex ab-flex-column">
+          <span class="ab-text-body-xs ab-text-secondary"
+            >ギフティ</span
+          >
+          <span class="ab-text-body-s">giftee Box</span>
+        </div>
+      </td>
+      <td class="ab-Table-cell">¥500</td>
+      <td class="ab-Table-cell">1〜2営業日</td>
+      <td class="ab-Table-cell">あり</td>
+      <td class="ab-Table-cell">
+        <span class="ab-Tooltip ab-Tooltip-top"
+          >１ヶ月後の月末
+          <span class="ab-Tooltip-description"
+            >テーブルからはみ出して要素を表示できます</span
+          >
+        </span>
+      </td>
+    </tr>
+    <tr class="ab-Table-body-row">
+      <td class="ab-Table-cell ab-flex ab-flex-items-center">
+        <div class="ab-Checkbox-wrapper ab-mr-2">
+          <div class="ab-Checkbox">
+            <input type="checkbox" class="ab-Checkbox-input" />
+            <span class="ab-Checkbox-box"></span>
+          </div>
+        </div>
+        <img src="${GifteeBox}" class="ab-mx-2" style="height: 56px" />
+        <div class="ab-flex ab-flex-column">
+          <span class="ab-text-body-xs ab-text-secondary"
+            >ギフティ</span
+          >
+          <span class="ab-text-body-s">giftee Box</span>
+        </div>
+      </td>
+      <td class="ab-Table-cell">¥500</td>
+      <td class="ab-Table-cell">1〜2営業日</td>
+      <td class="ab-Table-cell">あり</td>
+      <td class="ab-Table-cell">
+        <span class="ab-Tooltip ab-Tooltip-top"
+          >１ヶ月後の月末
+          <span class="ab-Tooltip-description"
+            >テーブルからはみ出して要素を表示できます</span
+          >
+        </span>
+      </td>
+    </tr>
+  </tbody>
+</table>
+    `;
+  },
+  args: {},
+  parameters: {
+    pseudo: {
+      hover: '#hover',
+      active: '#active',
+      focus: '#focus',
+    },
+  },
+};


### PR DESCRIPTION
## 概要
`table`のコンポーネントにおいて`cell`に対してデフォルトで`overflow: hidden;`が設定されていることで`cell`からはみ出した要素が切り取られてしまう
`ab-Table-overflow-visible`のクラスをセットすることで`cell`からはみ出すような要素も表示できるようにしました

ユーザー影響を考慮してデフォルトは現状のまま使用者が`overflow: hidden;`か`overflow: visible;`かを選択できるようにしました

### 主な変更点
- `ab-Table-overflow-visible`のクラスを追加

## スクリーンショット

### 元々のスクリーンショット
<img width="1000" height="144" alt="image" src="https://github.com/user-attachments/assets/6f1bdb8c-2483-48dc-b0b2-76788ec4a42c" />

### 変更後のスクリーンショット
<img width="966" height="152" alt="image" src="https://github.com/user-attachments/assets/26b39c9d-8058-4b8d-8118-22183969e7e2" />


## ユーザ影響
- **後方互換性**: 上書きするクラスを作成したので既存の実装に影響はありません
- **Breaking Changes**: なし

## その他
少し限定的な処理と感じつつ`overflow: visible;`に上書きするような処理しか思い浮かばす、ただテーブル上でtooltipを使うケースもあるのでどうにか解消したく今回のような変更にしました
