### PR TITLE
Storybook の autodoc が無効になっているのを修正

### DIFF
--- a/packages/css/.storybook/preview.tsx
+++ b/packages/css/.storybook/preview.tsx
@@ -3,6 +3,7 @@ import { Canvas } from '@storybook/addon-docs/blocks';
 import type { Preview, Parameters } from '@storybook/html-vite';
 
 const preview: Preview = {
+  tags: ['autodocs'],
   beforeEach: () => {
     const stories = document.getElementsByClassName('docs-story');
     for (const story of stories) {

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
-  addons: ['@storybook/addon-a11y'],
+  addons: ['@storybook/addon-docs', '@storybook/addon-a11y'],
   framework: {
     name: '@storybook/react-vite',
     options: {},

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -11,6 +11,7 @@ import type { Preview } from '@storybook/react-vite';
 import '@giftee/abukuma-css';
 
 const preview: Preview = {
+  tags: ['autodocs'],
   beforeEach: () => {
     const stories = document.getElementsByClassName('docs-story');
     for (const story of stories) {


### PR DESCRIPTION
## 概要

* Storybook の autodoc が無効になっているのを修正する

## スクリーンショット

* なし

## ユーザ影響

* [ドキュメント](https://abukuma.netlify.app/)の Storybook 埋め込みが見えるようになります
