### PR TITLE
【CSS】アコーディオンで設定していたcolorプロパティをbackground-colorプロパティに変更

### DIFF
--- a/.changeset/big-apes-clean.md
+++ b/.changeset/big-apes-clean.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": patch
+---
+
+colorプロパティをbackground-colorプロパティに変更した

--- a/.changeset/big-apes-clean.md
+++ b/.changeset/big-apes-clean.md
@@ -2,4 +2,4 @@
 "@giftee/abukuma-css": patch
 ---
 
-colorプロパティをbackground-colorプロパティに変更した
+[fix: Accordion] 開閉アイコンを黒色からブランドカラーに変更

--- a/packages/css/src/components/accordion/index.scss
+++ b/packages/css/src/components/accordion/index.scss
@@ -67,14 +67,14 @@ $minus-url: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvM
 
     &::before {
       content: '';
-      background-image: url($plus-url);
-      background-size: contain;
-      background-repeat: no-repeat;
-      background-position: center;
+      mask-image: url($plus-url);
+      mask-size: contain;
+      mask-repeat: no-repeat;
+      mask-position: center;
+      background-color: var(--accordion-summary-icon-color);
       width: 16px;
       height: 16px;
       font-size: var(--accordion-summary-icon-size);
-      color: var(--accordion-summary-icon-color);
       position: absolute;
       right: var(--ab-semantic-spacing-4);
       top: 50%;
@@ -85,12 +85,10 @@ $minus-url: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvM
   &[open] {
     .ab-Accordion-summary::before {
       content: '';
-      background-image: url($minus-url);
-      background-size: contain;
-      background-repeat: no-repeat;
-      background-position: center;
-      width: 16px;
-      height: 16px;
+      mask-image: url($minus-url);
+      mask-size: contain;
+      mask-repeat: no-repeat;
+      mask-position: center;
     }
   }
 
@@ -99,7 +97,7 @@ $minus-url: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvM
 
     .ab-Accordion-summary {
       &::before {
-        color: var(--accordion-hover-summary-icon-color);
+        background-color: var(--accordion-hover-summary-icon-color);
       }
     }
   }
@@ -109,7 +107,7 @@ $minus-url: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvM
 
     .ab-Accordion-summary {
       &::before {
-        color: var(--accordion-focus-visible-summary-icon-color);
+        background-color: var(--accordion-focus-visible-summary-icon-color);
       }
     }
   }
@@ -119,7 +117,7 @@ $minus-url: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvM
 
     .ab-Accordion-summary {
       &::before {
-        color: var(--accordion-active-summary-icon-color);
+        background-color: var(--accordion-active-summary-icon-color);
       }
     }
   }
@@ -152,7 +150,7 @@ $minus-url: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvM
     border-radius: var(--ab-semantic-border-radius-lg);
 
     &::before {
-      color: var(--accordion-disabled-summary-icon-color);
+      background-color: var(--accordion-disabled-summary-icon-color);
     }
   }
 }


### PR DESCRIPTION
## 概要
::before記事要素でアイコンを`background-image`で描画していたが、色は`color`プロパティで指定していた
colorはbackground-imageには効かないので、`background-color`で統一した
<!-- 変更内容を明記してください -->

## スクリーンショット
ユーザ影響に添付
<!-- スクリーンショットが必要であれば貼り付けてください -->

## ユーザ影響

<!-- 見た目の変更なら前後のスクリーンショットを、breaking change なら migration step を書いてください -->
before
<img width="780" height="441" alt="image" src="https://github.com/user-attachments/assets/b4407298-5b27-47c0-8f41-0e90aa2e7d96" />

after
<img width="1061" height="639" alt="image" src="https://github.com/user-attachments/assets/d36af3eb-a66e-426f-a2e4-1d474117082f" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/giftee/design-system/pull/1064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
