### PR TITLE
【CSS】Selectボタンのアイコンの色をsecondaryに変更

### DIFF
--- a/.changeset/frank-news-prove.md
+++ b/.changeset/frank-news-prove.md
@@ -1,0 +1,5 @@
+---
+"@giftee/abukuma-css": minor
+---
+
+[fix: Select] ドロップダウンの色をブランドカラーから灰色に変更

--- a/packages/css/src/components/select/index.scss
+++ b/packages/css/src/components/select/index.scss
@@ -2,7 +2,7 @@
 @use '../textfield';
 
 .ab-Select-icon {
-  --select-icon-color: var(--ab-semantic-color-text-brand);
+  --select-icon-color: var(--ab-semantic-color-text-secondary);
 }
 
 .ab-Select {


### PR DESCRIPTION
## 概要
Selectボタンのアイコンの色をsecondaryに変更します
<!-- 変更内容を明記してください -->

## スクリーンショット
<img width="538" height="497" alt="SCR-20260514-okss" src="https://github.com/user-attachments/assets/b00cbf8b-5124-4e46-8c12-7097a01f038a" />
<!-- スクリーンショットが必要であれば貼り付けてください -->

## ユーザ影響

<!-- 見た目の変更なら前後のスクリーンショットを、breaking change なら migration step を書いてください -->
Before
<img width="686" height="559" alt="SCR-20260514-okhb" src="https://github.com/user-attachments/assets/86b6ff90-7ed3-4f2c-9bd0-f6399c725243" />

After
<img width="538" height="497" alt="SCR-20260514-okss" src="https://github.com/user-attachments/assets/b00cbf8b-5124-4e46-8c12-7097a01f038a" />

close #580 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/giftee/design-system/pull/1111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->